### PR TITLE
French translation: update '2fa' section.

### DIFF
--- a/fr.yml
+++ b/fr.yml
@@ -2,15 +2,15 @@
 fr:
   2fa:
     5strike:
-      return: Retour à la page d'accueil
-      subtitle: Merde, pour des raisons de sécurité, vous devrez attendre deux heures avant de pouvoir essayer ouvrir une session encore.
-      title: Règle de Cinq Grèves
-    cta: C'est moi, laisser moi entrer!
-    error: "<strong>Kinky Opérateur:</strong> Doh&hellip; le code de vérification au dessus semble incorrect. S'il vous plaît vérifier que le numéro au dessus égale ce que vous recevez par nous et essayer encore."
-    label: Code d'identification
-    page_title: 2-Factor Authentification
-    subtitle: 2-Factor moi bébé!
-    title: Code Secret
+      return: Retour à la page d’accueil
+      subtitle: Merdre, pour des raisons de sécurité, vous devrez attendre deux heures avant de pouvoir ré-essayer d’ouvrir une session.
+      title: Règle des cinq essais
+    cta: C’est moi, laissez-moi entrer !
+    error: "<strong>Kinky Opérateur :</strong> Doh… le code de vérification ci-dessus semble incorrect. Vérifiez s’il vous plaît que le numéro ci-dessus est identique à celui que vous avez reçu de nous, et ré-essayez."
+    label: Code d’identification
+    page_title: Validation à 2 facteurs
+    subtitle: 2-factorise-moi bébé !
+    title: Code secret
   about:
     contact_info: Informations de contact
     email_us: Envoyez-nous un courriel à <a href="mailto:support@fetlife.com">support@fetlife.com</a> et nous reviendrons vers vous vite!


### PR DESCRIPTION
Fix some grammar (mostly mismatches between infinitive and 'polite' second plural person, `laisser` -> `laissez`),
typography rules (non-breakable space before 'high' punctuation signs like `!` or `:`, and do not capitalize titles),
slightly reformulated some parts to make them sound more “frenchy”,
tried to fix some translations (`five strikes rule` -> `règle des cinq essais`),
and replaced `merde` by `merdre` (trying to mimic `shit/shoot`, https://fr.wiktionary.org/wiki/merdre)

PS: thanks for working on translating fetlife (and your hard work in general!) :D