### PR TITLE
Propose not allowing comments on language files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,14 @@ You can help out in multiple ways, and you don't even need to be multilingual to
 
 - [Report any grammatical issues](https://github.com/fetlife/translations/issues) you come across in any language, including English, on FetLife.
 - Submit improvements to our existing translations by clicking on the pencil in the right hand corner of every file.
-- Translate FetLife into a language you are well versed in creating a new file with the proper language code, copying the contents of en.yml into the new file, translating as many strings as you can, and finally submitting the translation in a pull request to us.   
+- Translate FetLife into a language you are well versed in creating a new file with the proper language code, copying the contents of en.yml into the new file, translating as many strings as you can, and finally submitting the translation in a pull request to us.
 
 
 ## Coding Conventions
 
-Please try to always write a clear log message for each of your commits. One-line messages are fine for small changes, but bigger changes should be a bit meatier.
+- Please try to always write a clear log message for each of your commits. One-line messages are fine for small changes, but bigger changes should be a bit meatier.
+- Avoid adding `# comments` to the translation files. Usually they are just noise - style preferences should be discussed during the code review and TODOs should be converted into actionable GitHub issues.
+
+--------------------
+
+Thank you, merci, obrigado, gracias, danke, ευχαριστό!


### PR DESCRIPTION
Comments on data files are usually just noise - stuff that could be either discussed on the Pull Request (style preferences) or converted into actionable GitHub issues (TODOs). That's my motivation for thumbing down comments.

Debating over translations is really common - hardcore enthusiasts/purists could endlessly debate over every single line (and for good reason). That kind of noise is detrimental, not only because it will increase the file size, but because even the comments themselves would have to be maintained as we fine tune the translations. That kind of information is better stored and discussed over issues, IMO.

Also, having 1:1 number of lines among the files is a positive thing. It's really easy to spot if something went wrong with a merge/automated i18n task.