### PR TITLE
Fix member stats content counters

### DIFF
--- a/de.yml
+++ b/de.yml
@@ -207,14 +207,14 @@ de:
     title: Wir werden Dich vermissen!
   member_stats:
     pics:
-      one: Bild
-      other: Bilder
+      one: 1 Bild
+      other: "%{count} Bilder"
     posts:
-      one: Text
-      other: Texte
+      one: 1 Text
+      other: "%{count} Texte"
     vids:
-      one: Video
-      other: Videos
+      one: 1 Video
+      other: "%{count} Videos"
   nav:
     events: Veranstaltungen
     explore: Entdecken

--- a/en.yml
+++ b/en.yml
@@ -207,14 +207,14 @@ en:
     title: We'll Miss You!
   member_stats:
     pics:
-      one: pic
-      other: pics
+      one: 1 pic
+      other: "%{count} pics"
     posts:
-      one: post
-      other: posts
+      one: 1 post
+      other: "%{count} posts"
     vids:
-      one: vid
-      other: vids
+      one: 1 vid
+      other: "%{count} vids"
   nav:
     events: Events
     explore: Explore

--- a/es.yml
+++ b/es.yml
@@ -207,14 +207,14 @@ es:
     title: “¡Le echaremos de menos!"
   member_stats:
     pics:
-      one: foto
-      other: fotos
+      one: 1 foto
+      other: "%{count} fotos"
     posts:
-      one: mensaje
-      other: mensajes
+      one: 1 mensaje
+      other: "%{count} mensajes"
     vids:
-      one: vid
-      other: vids
+      one: 1 vid
+      other: "%{count} vids"
   nav:
     events: Eventos
     explore: Explorar

--- a/fr.yml
+++ b/fr.yml
@@ -207,14 +207,14 @@ fr:
     title: Tu nous as manqué!
   member_stats:
     pics:
-      one: photo
-      other: photos
+      one: 1 photo
+      other: "%{count} photos"
     posts:
-      one: post
-      other: postes
+      one: 1 post
+      other: "%{count} postes"
     vids:
-      one: vidéo
-      other: vidéos
+      one: 1 vidéo
+      other: "%{count} vidéos"
   nav:
     events: Évènements
     explore: Explorer

--- a/gr.yml
+++ b/gr.yml
@@ -207,14 +207,14 @@ gr:
     title: Θα μας λείψεις!
   member_stats:
     pics:
-      one: εικόνα
-      other: εικόνες
+      one: 1 εικόνα
+      other: "%{count} εικόνες"
     posts:
-      one: γραπτό
-      other: γραπτά
+      one: 1 γραπτό
+      other: "%{count} γραπτά"
     vids:
-      one: βίντεο
-      other: βίντεος
+      one: 1 βίντεο
+      other: "%{count} βίντεος"
   nav:
     events: Εκδηλώσεις
     explore: εξερευνώ

--- a/pt.yml
+++ b/pt.yml
@@ -207,14 +207,14 @@ pt:
     title: Sentiremos sua falta!
   member_stats:
     pics:
-      one: foto
-      other: fotos
+      one: 1 foto
+      other: "%{count} fotos"
     posts:
-      one: postagem
-      other: postagens
+      one: 1 postagem
+      other: "%{count} postagens"
     vids:
-      one: vídeo
-      other: vídeos
+      one: 1 vídeo
+      other: "%{count} vídeos"
   nav:
     events: Eventos
     explore: Explorar

--- a/sk.yml
+++ b/sk.yml
@@ -209,17 +209,17 @@ sk:
     title: Budeš nám chýbať!
   member_stats:
     pics:
-      one: fotka
-      few: fotky
-      other: fotiek
+      one: 1 fotka
+      few: "%{count} fotky"
+      other: "%{count} fotiek"
     posts:
-      one: príspevok
-      few: príspevky
-      other: príspevkov
+      one: 1 príspevok
+      few: "%{count} príspevky"
+      other: "%{count} príspevkov"
     vids:
-      one: video
-      few: videá
-      other: videii
+      one: 1 video
+      few: "%{count} videá"
+      other: "%{count} videii"
   nav:
     events: Udalosti
     explore: Objavuj


### PR DESCRIPTION
Count should be inside translation string and not prepended in application code. This also makes it consistent with rest of similar translation strings.