### PR TITLE
Translation updates for Bulgarian

### DIFF
--- a/locales/bg.yml
+++ b/locales/bg.yml
@@ -93,7 +93,7 @@ bg:
       close: затвори
       more: още
       reply: Отговори
-    title: Activity Feed
+    title: Стена
   following:
     follow: Follow
     following: Following
@@ -112,9 +112,9 @@ bg:
         subtitle: Нека ти помогна.
         title: Забрави паролата?
       step2:
-        page_title: "\"МОЖЕ БИ\" имате поща"
+        page_title: '&bdquo;МОЖЕ БИ&ldquo; имате поща'
         subtitle: Ако профил с имейл <strong>%{given_email}</strong> съществува, значи сме ви изпратили инструкции как да смените паролата си.
-        title: "\"МОЖЕ БИ\" имате поща!"
+        title: '&bdquo;Може би&ldquo; имате поща!'
       update_email: промени имейл адреса
       warning: "<strong>Министъра на отбраната:</strong> От съображения за сигурност не можем да ви кажем дали даден имейл адрес е в базата ни от данни. Ако не получите имейл от нас най-вероятно е защото нямаме профил с този имейл адрес."
     mobile:
@@ -131,13 +131,13 @@ bg:
         subtitle: Нека ти помогна.
         title: Забрави паролата?
       step2:
-        cta: Потвърдете че сте вие &#8482;
+        cta: Потвърдете че това сте вие &#8482;
         error_code_match: "<strong>Извратения оператор:</strong> Кодът за потвърждение който въведохте е неверен. Уверете се че горното число съответства на това което сте получили от нас и опитайте пак. Това е запис."
         inexisting_number: Ако до няколко минути не получите SMS от нас, сигурно е защото нямаме профил с този номер. Предлагаме ви или <a href="%{forgot_password_email_path}">да опитате да смените паролата си по друг начин</a> или <a href="%{signup_path}">да откриете нов профил във FetLife</a>.
         label: Код за потвърждение
         page_title: Въведете код за потвърждение
         placeholder: 6-цифрен код за потвърждение
-        subtitle: We &ldquo;might&rdquo; have just sent you a text message.
+        subtitle: '&bdquo;Може би&ldquo; току-що ви изпратихме SMS.'
         title: Въведете код за потвърждение
       warning: "<strong>Министъра на отбраната:</strong> От съображения за сигурност не можем да ви кажем дали даден мобилен номер е в базата ни от данни. Ако не получите SMS от нас най-вероятно е защото нямаме профил с този номер."
     next_step: следваща стъпка
@@ -149,17 +149,17 @@ bg:
     sub_header: Follow your gut, it always nose.
     subnav:
       community: На общността
-      community_short: На общността
+      community_short: Общност
       content: За съдържанието
-      content_short: За съдържанието
+      content_short: Съдържание
       group_leader: За водачи на група
-      group_leader_short: За водачи на група
+      group_leader_short: Групи
     title: Правила
   invite_a_friend:
     cancel_button: отмени
     cancel_notice: Поканата към %{email} беше отменена.
     cta: Поканете приятел във FetLife
-    error: Имаме проблеми с изпращането на покана към горния имейл адрес. Препоръчваме да се уверите в правописа или да опитате с друг адрес.
+    error: Имаме проблем с изпращането на покана към този имейл адрес. Уверете се че няма правописна грешка или опитайте с друг адрес.
     invitations_accepted: Приети покани
     invitations_sent: Изпратени покани
     labels:
@@ -174,7 +174,7 @@ bg:
     title_step2: Изпратени покани
     view_invitations: вижте поканите си
   landing_page:
-    footer: "<strong>%{member_count} Членовете</strong> споделят <strong>%{picture_count} снимки</strong> и <strong>%{video_count} клипове</strong>, участват в <strong>%{discussion_count} дискусии</strong> в <strong>%{group_count} групи</strong>, ще ходят на <strong>%{event_count} предстоящи събития</strong>, и четат <strong>%{post_count} публикации</strong>. <em>Извратен рай!</em>"
+    footer: "<strong>%{member_count} членове</strong> споделят <strong>%{picture_count} снимки</strong> и <strong>%{video_count} клипове</strong>, участват в <strong>%{discussion_count} дискусии</strong> в <strong>%{group_count} групи</strong>, ще ходят на <strong>%{event_count} предстоящи събития</strong>, и четат <strong>%{post_count} публикации</strong>. <em>Извратен рай!</em>"
     login_button: Влизане във FetLife
     signup_button: Регистрация във FetLife
     subtitle: Като Facebook, но от извратеняци като теб и мен. Мислим че така е по-забавно. А ти?
@@ -259,7 +259,7 @@ bg:
     button: Смени основния език
     help_translate: Посетете <a href="https://github.com/fetlife/translations">проекта ни за превод</a> в GitHub и помогнете да направим FetLife достъпен за повече от извратените ни приятели <span class="amp">&amp</span> общности.
     language_name: Български
-    sub_header: Hi, hallo, olá, bonjour, ciao, ahoj, opa, szia!
+    sub_header: Hi, hallo, olá, bonjour, ciao, ahoj, opa, szia, здрасти!
     title: Изберете език
   settings_account:
     2fa_cta: Включи двустепенното удостоверяване
@@ -298,7 +298,7 @@ bg:
     cta: Запиши настройките за поверителност
     following: Следване
     page_title: Настройки за поверителност
-    subtitle: Served the way you like it.
+    subtitle: Поднесено, както го обичаш.
     title: Поверителност
     warning: "<strong>Изключително важно</strong>: При изключване на следването ще спрете да следвате всички които в момента следват вас. Няма връщане назад. Наистина."
   settings_profile:
@@ -362,9 +362,9 @@ bg:
     error_birthdate_too_young: Не сте достатъчно възрастни (трябва да сте поне на 18 години).
     error_city_missing: Трябва да изберете град
     error_country_missing: Трябва да изберете държава
-    error_email: Имаме проблеми с обработването на горния имейл адрес. Препоръчваме да се уверите в правописа или да опитате с друг адрес.
+    error_email: Имаме проблем с обработването на този имейл адрес. Уверете се че няма правописна грешка или опитайте с друг адрес.
     error_gender_required: Трябва да изберете пол
-    error_nickname: Прякора вече е зает.
+    error_nickname: Прякора е вече зает.
     error_nickname_required: Прякора е задължителен.
     error_password_range: Паролата трябва да бъде между 4 и 100 символа
     error_password_required: Паролата е задължителна
@@ -428,7 +428,7 @@ bg:
   subnav:
     feed:
       activity_feed: Стена
-      activity_feed_short: Начало
+      activity_feed_short: Стена
       fp: Свежо<span class="a-ampersand">&amp;</span>Перверзно
       fp_short: Свежо
       kp: Извратено<span class="a-ampersand">&amp;</span>Популярно
@@ -442,8 +442,8 @@ bg:
       pictures_short: Снимки
       videos: Клипове
       videos_short: Клипове
-      writings: Документи
-      writings_short: Документи
+      writings: Публикации
+      writings_short: Публикации
     settings:
       account: Регистрация
       account_short: Регистрация


### PR DESCRIPTION
Fix double quotes to match Bulgarian standard. (bdquo and ldquo)
Improved wording in many translations.
All references to 'writings' now use the same Bulgarian word.
All references to 'activity feed' now use the same Bulgarian word.
A couple new translations. (6 strings left to translate)