### PR TITLE
Update Password Minimum Length to 8

### DIFF
--- a/locales/bg.yml
+++ b/locales/bg.yml
@@ -190,7 +190,7 @@ bg:
   reset_password:
     cta: "Смени паролата ми"
     error_confirmation_match: "Потвърждението на паролата не съответства на паролата"
-    error_password_range: "Паролата трябва да е с дължина между 4 и 100 символа"
+    error_password_range: "Паролата трябва да е с дължина между 8 и 100 символа"
     error_token_expired: "Кодът за смяна на парола е изтекъл, моля заяви си нов"
     error_token_invalid: "Кодът за смяна на парола е невалиден"
     footnote: "<b>Pro Tip:</b> Помни паролата си."
@@ -322,7 +322,7 @@ bg:
     error_nickname_characters: "Прякорът може да съдържа само букви, цифри, тирета и долна черта; никакви интервали."
     error_nickname_length: "Прякорът трябва да е с дължина между 2 и 16 символа."
     error_nickname_required: "Прякорът е задължителен."
-    error_password_range: "Паролата трябва да е с дължина между 4 и 100 символа."
+    error_password_range: "Паролата трябва да е с дължина между 8 и 100 символа."
     error_password_required: "Паролата е задължителна."
     error_role_required: "Трябва да избереш роля."
     error_sexual_orientation_required: "Трябва да избереш сексуална ориентация."

--- a/locales/bg.yml
+++ b/locales/bg.yml
@@ -2,159 +2,159 @@
 bg:
   2fa:
     5strike:
-      return: връщане към главната страница
-      subtitle: Хм, от съображения за сигурност ще трябва да изчакаш два часа преди да влезеш отново.
-      title: Втори жълт картон
-    cta: Аз съм, пуснете ме да вляза!
+      return: "връщане към главната страница"
+      subtitle: "Хм, от съображения за сигурност ще трябва да изчакаш два часа преди да влезеш отново."
+      title: "Втори жълт картон"
+    cta: "Аз съм, пуснете ме да вляза!"
     error: "<strong>Извратеният оператор:</strong> Ъ&hellip; горният код за потвърждение не изглежда наред. Моля, увери се че горното число съответства на това което получи от нас и опитай пак."
-    label: Код за удостоверяване
-    page_title: Двуетапно удостоверяване
+    label: "Код за удостоверяване"
+    page_title: "Двуетапно удостоверяване"
     subtitle: 2-Factor me baby!
-    title: Таен код
+    title: "Таен код"
   about:
-    contact_info: Данни за връзка
+    contact_info: "Данни за връзка"
     email_us: Пиши ни на <a href="mailto:support@fetlife.com">support@fetlife.com</a> и до една наносекунда ще ти отговорим!
-    europe: Европа
-    got_question: Имаш въпрос? Трябва ти помощ?
-    north_america: Северна Америка
-    one_love: Една любов, един живот, и много извращения.
-    snail_mail: Поща
-    sub_header: Не ни бъркай със спартанците.
-    title: Ние. Сме. FetLife!
+    europe: "Европа"
+    got_question: "Имаш въпрос? Трябва ти помощ?"
+    north_america: "Северна Америка"
+    one_love: "Една любов, един живот, и много извращения."
+    snail_mail: "Поща"
+    sub_header: "Не ни бъркай със спартанците."
+    title: "Ние. Сме. FetLife!"
   components:
     step: Step
   feed:
-    comment: Коментирай
+    comment: "Коментирай"
     comments_count:
       one: 1 коментар
       other: "%{count_with_delimiter} коментара"
     composer:
-      button: Кажи го
-      placeholder: Какво казваш?
-    love: Харесай
-    loved_hover: Сърцеразбивач! :-(
+      button: "Кажи го"
+      placeholder: "Какво казваш?"
+    love: "Харесай"
+    loved_hover: "Сърцеразбивач! :-("
     loves_count:
       one: 1 харесване
       other: "%{count_with_delimiter} харесвания"
     modal:
-      close: затвори
-      more: още
-      reply: Отговори
-    title: Стена
+      close: "затвори"
+      more: "още"
+      reply: "Отговори"
+    title: "Стена"
   following:
     follow: Follow
     following: Following
   footer:
-    about: Информация
-    help: Помощ
-    privacy: Поверителност
+    about: "Информация"
+    help: "Помощ"
+    privacy: "Поверителност"
   forgot_password:
     email:
-      cta: Пратете ми имейл с указания
-      error_forgot_email: Имейл адресът е задължителен.
-      error_invalid_email: Това не прилича на валиден имейл адрес. Прегледай го и го изпрати отново, моля.
-      error_quota: Можем да изпращаме само два имейла на час към даден имейл адрес. Моля, провери дали имейла ни не е попаднал в спам папката ти. Ако не намираш нищо в спам папката, препоръчваме ти да използваш някой от другите методи да се върнеш в профила си.
-      placeholder: Имейл адрес
+      cta: "Пратете ми имейл с указания"
+      error_forgot_email: "Имейл адресът е задължителен."
+      error_invalid_email: "Това не прилича на валиден имейл адрес. Прегледай го и го изпрати отново, моля."
+      error_quota: "Можем да изпращаме само два имейла на час към даден имейл адрес. Моля, провери дали имейла ни не е попаднал в спам папката ти. Ако не намираш нищо в спам папката, препоръчваме ти да използваш някой от другите методи да се върнеш в профила си."
+      placeholder: "Имейл адрес"
       step1:
-        page_title: Смени паролата по имейл
-        subtitle: Нека ти помогна.
-        title: Забрави паролата?
+        page_title: "Смени паролата по имейл"
+        subtitle: "Нека ти помогна."
+        title: "Забрави паролата?"
       step2:
         page_title: "&bdquo;МОЖЕ БИ&ldquo; имаш поща"
-        subtitle: Ако профил с имейл <span class='fw5'>%{given_email}</span> съществува, значи сме ти изпратили инструкции как да смениш паролата си.
+        subtitle: "Ако профил с имейл <span class='fw5'>%{given_email}</span> съществува, значи сме ти изпратили инструкции как да смениш паролата си."
         title: "&bdquo;Може би&ldquo; имаш поща!"
-      update_email: промени имейл адреса
+      update_email: "промени имейл адреса"
       warning: "<strong>Министърът на отбраната:</strong> От съображения за сигурност не можем да ви кажем дали даден имейл адрес е в базата ни от данни. Ако не получите имейл от нас, най-вероятно е защото нямаме профил с този имейл адрес."
     mobile:
       5strike:
-        return: връщане към главната страница
-        subtitle: Хм, от съображения за сигурност ще трябва да изчакаш два часа преди да влезеш отново.
-        title: Втори жълт картон
-      cta: Пратете ми SMS
+        return: "връщане към главната страница"
+        subtitle: "Хм, от съображения за сигурност ще трябва да изчакаш два часа преди да влезеш отново."
+        title: "Втори жълт картон"
+      cta: "Пратете ми SMS"
       error_country_code: "<strong>Извратеният оператор:</strong> Увери се че номера ти започва с кода на твоята държава: +1 за САЩ и Канада, +44 за Великобритания, +61 за Австралия, +31 за Холандия, +49 за Германия, +33 за Франция, и т.н."
       error_quota: "<strong>Извратеният оператор:</strong> Хм, можем да изпращаме не повече от 3 SMS-а на 24 часа към даден мобилен номер. Без значение дали е в базата ни от данни или не."
       pro_tip: "<strong>Pro Tip:</strong> Увери се че номера ти започва с кода на твоята държава: +1 за САЩ и Канада, +44 за Великобритания, +61 за Австралия, +31 за Холандия, +49 за Германия, +33 за Франция, и т.н."
       step1:
-        page_title: Смени паролата по SMS
-        subtitle: Нека ти помогна.
-        title: Забрави паролата?
+        page_title: "Смени паролата по SMS"
+        subtitle: "Нека ти помогна."
+        title: "Забрави паролата?"
       step2:
-        cta: Потвърди че това си ти &#8482;
+        cta: "Потвърди че това си ти &#8482;"
         error_code_match: "<strong>Извратеният оператор:</strong> Кодът за потвърждение който въведе е неверен. Увери се че горното число съответства на това което получи от нас и опитай пак. Това е запис."
         inexisting_number: Ако до няколко минути не получиш SMS от нас, сигурно е защото нямаме профил с този номер. Предлагаме ти или <a href="%{forgot_password_email_path}">да опиташ да смениш паролата си по друг начин</a> или <a href="%{signup_path}">да откриеш нов профил във FetLife</a>.
-        label: Код за потвърждение
-        page_title: Въведи код за потвърждение
+        label: "Код за потвърждение"
+        page_title: "Въведи код за потвърждение"
         placeholder: 6-цифрен код за потвърждение
         subtitle: "&bdquo;Може би&ldquo; току-що ти изпратихме SMS."
-        title: Въведи код за потвърждение
+        title: "Въведи код за потвърждение"
       warning: "<strong>Министърът на отбраната:</strong> От съображения за сигурност не можем да ви кажем дали даден мобилен номер е в базата ни от данни. Ако не получите SMS от нас най-вероятно е защото нямаме профил с този номер."
-    next_step: следваща стъпка
-    return_to_login: връщане към входа
-    tab_email: Имейл
-    tab_mobile: Телефон
+    next_step: "следваща стъпка"
+    return_to_login: "връщане към входа"
+    tab_email: "Имейл"
+    tab_mobile: "Телефон"
   guidelines:
-    last_updated: 'Последна промяна:'
+    last_updated: "Последна промяна:"
     subnav:
-      community: На общността
-      content: За съдържанието
-      group_leader: За водачи на група
-    title: Правила
+      community: "На общността"
+      content: "За съдържанието"
+      group_leader: "За водачи на група"
+    title: "Правила"
   invite_a_friend:
-    cancel_button: отмени
-    cancel_notice: Поканата към %{email} беше отменена.
-    cta: Покани приятел във FetLife
-    error: Имаме проблем с изпращането на покана към този имейл адрес. Увери се че няма правописна грешка или опитай с друг адрес.
-    error_forgot_email: Имейл адресът е задължителен.
-    invitations_accepted: Приети покани
-    invitations_sent: Изпратени покани
+    cancel_button: "отмени"
+    cancel_notice: "Поканата към %{email} беше отменена."
+    cta: "Покани приятел във FetLife"
+    error: "Имаме проблем с изпращането на покана към този имейл адрес. Увери се че няма правописна грешка или опитай с друг адрес."
+    error_forgot_email: "Имейл адресът е задължителен."
+    invitations_accepted: "Приети покани"
+    invitations_sent: "Изпратени покани"
     labels:
-      email: Имейл адрес
-      friends_email: 'Изпрати покана до:'
-      friends_email_sub: Остават %{count} покани
-    next_step: следваща стъпка
-    return_to_feed: връщане към стената
+      email: "Имейл адрес"
+      friends_email: "Изпрати покана до:"
+      friends_email_sub: "Остават %{count} покани"
+    next_step: "следваща стъпка"
+    return_to_feed: "връщане към стената"
     subtitle_step1:
-      one: Имаш 1 оставаща покана.
-      other: Имаш %{count_with_delimiter} оставащи покани.
-    subtitle_step2: Изпратихме покана от твое име на %{email}.
-    title_step1: Покани приятел
-    title_step2: Изпратени покани
-    view_invitations: виж поканите си
+      one: "Имаш 1 оставаща покана."
+      other: "Имаш %{count_with_delimiter} оставащи покани."
+    subtitle_step2: "Изпратихме покана от твое име на %{email}."
+    title_step1: "Покани приятел"
+    title_step2: "Изпратени покани"
+    view_invitations: "виж поканите си"
   landing_page:
     footer: <span class="fw5">%{member_count} члена</span><span> споделят </span><span class="fw5">%{picture_count} снимки</span><span> и </span><span class="fw5">%{video_count} клипа</span><span>, участват в </span><span class="fw5">%{discussion_count} дискусии</span><span> в </span><span class="fw5">%{group_count} групи</span><span>, ще ходят на </span><span class="fw5">%{event_count} предстоящи събития</span><span>, и четат </span><span class="fw5">%{post_count} публикации</span><span>. </span><span><i>Извратен рай!</i></span>
-    login_button: Влизане във FetLife
-    signup_button: Регистрация във FetLife
-    subtitle: Като Facebook, но от извратеняци като теб и мен. Мислим че така е по-забавно. А ти?
+    login_button: "Влизане във FetLife"
+    signup_button: "Регистрация във FetLife"
+    subtitle: "Като Facebook, но от извратеняци като теб и мен. Мислим че така е по-забавно. А ти?"
     title: FetLife е Социалната Мрежа за BDSM, Fetish & Kinky общностите.
   legalese:
     subnav:
-      2257_exempt: Освободени от 2257
-      legal_requests: Правни искания
-      privacy: Декларация за поверителност
-      terms: Условия за ползване
-    title: Правни въпроси
+      2257_exempt: "Освободени от 2257"
+      legal_requests: "Правни искания"
+      privacy: "Декларация за поверителност"
+      terms: "Условия за ползване"
+    title: "Правни въпроси"
   lockout:
-    subtitle: Задействахте охранителната ни система.
-    title: Охрана, охрана, охрана!
+    subtitle: "Задействахте охранителната ни система."
+    title: "Охрана, охрана, охрана!"
   login:
-    button: Влизане във FetLife
+    button: "Влизане във FetLife"
     error_flash: Моля, свържи се със <a href="mailto:support@fetlife.com">support@fetlife.com</a> за да ти помогнем да влезеш.
-    error_login_blank: Името не може да е празно.
-    error_not_authenticated: Съжалявам, приятел, трябва да си влязъл за да стигнеш до тази страница. В случай че не си член, отнема по-малко от минута да се регистрираш.
-    error_not_found: Хм, не можахме да те намерим. Правилно ли въведе прякора и паролата си? (Паролите РаЗлИчАвАт ГЛАВНИ и малки букви)
-    error_password_blank: Паролата не може да е празна.
-    forgot_info: Забрави данните за влизане?
+    error_login_blank: "Името не може да е празно."
+    error_not_authenticated: "Съжалявам, приятел, трябва да си влязъл за да стигнеш до тази страница. В случай че не си член, отнема по-малко от минута да се регистрираш."
+    error_not_found: "Хм, не можахме да те намерим. Правилно ли въведе прякора и паролата си? (Паролите РаЗлИчАвАт ГЛАВНИ и малки букви)"
+    error_password_blank: "Паролата не може да е празна."
+    forgot_info: "Забрави данните за влизане?"
     labels:
-      nickname: Прякор или имейл
-      password: Парола
-      remember_me: Запомни ме, пак ще дойда.
-    not_a_member: Все още не си член? Регистрирай се във FetLife
-    subtitle: Липсваше ни… ама много!
-    title: Добре дошли у дома
+      nickname: "Прякор или имейл"
+      password: "Парола"
+      remember_me: "Запомни ме, пак ще дойда."
+    not_a_member: "Все още не си член? Регистрирай се във FetLife"
+    subtitle: "Липсваше ни… ама много!"
+    title: "Добре дошли у дома"
   logout:
-    log_in: Влез отново
-    subtitle: Ела пак да се видим!
-    title: Ще ни липсваш!
+    log_in: "Влез отново"
+    subtitle: "Ела пак да се видим!"
+    title: "Ще ни липсваш!"
   member_stats:
     pics:
       one: 1 снимка
@@ -166,250 +166,250 @@ bg:
       one: 1 клип
       other: "%{count_with_delimiter} клипа"
   nav:
-    events: Събития
-    explore: Разгледай
-    fetishes: Фетиши
-    groups: Групи
-    home: Начало
-    places: Места
-    search_placeholder: Търсене
+    events: "Събития"
+    explore: "Разгледай"
+    fetishes: "Фетиши"
+    groups: "Групи"
+    home: "Начало"
+    places: "Места"
+    search_placeholder: "Търсене"
   page_break:
-    of: от
+    of: "от"
   profile:
-    about_title: Списък с приятели
-    pictures_title: Снимки
-    videos_title: Клипове
+    about_title: "Списък с приятели"
+    pictures_title: "Снимки"
+    videos_title: "Клипове"
   promote_following:
-    button: Включи следването
-    ps: П.П. Можеш да го изключиш по всяко време.
-    skip: Не включвай следването
-    subtitle: Отдели приятелите от последователите си.
-    title: Въвеждаме следване
+    button: "Включи следването"
+    ps: "П.П. Можеш да го изключиш по всяко време."
+    skip: "Не включвай следването"
+    subtitle: "Отдели приятелите от последователите си."
+    title: "Въвеждаме следване"
   recommendations:
-    title: Препоръчани
+    title: "Препоръчани"
   reset_password:
-    cta: Смени паролата ми
-    error_confirmation_match: Потвърждението на паролата не съответства на паролата
-    error_password_range: Паролата трябва да е с дължина между 4 и 100 символа
-    error_token_expired: Кодът за смяна на парола е изтекъл, моля заяви си нов
-    error_token_invalid: Кодът за смяна на парола е невалиден
+    cta: "Смени паролата ми"
+    error_confirmation_match: "Потвърждението на паролата не съответства на паролата"
+    error_password_range: "Паролата трябва да е с дължина между 4 и 100 символа"
+    error_token_expired: "Кодът за смяна на парола е изтекъл, моля заяви си нов"
+    error_token_invalid: "Кодът за смяна на парола е невалиден"
     footnote: "<b>Pro Tip:</b> Помни паролата си."
-    label_enter: Нова парола
-    label_re_enter: Въведи новата парола отново
-    status_flash_success: Паролата ти беше сменена успешно.
-    subtitle: Не много къса, не много дълга, точно…
-    title: Смени паролата
+    label_enter: "Нова парола"
+    label_re_enter: "Въведи новата парола отново"
+    status_flash_success: "Паролата ти беше сменена успешно."
+    subtitle: "Не много къса, не много дълга, точно…"
+    title: "Смени паролата"
   select_language:
-    button: Смени основния език
+    button: "Смени основния език"
     help_translate: Посети <a class="silver" href="https://github.com/fetlife/translations">проекта ни за превод</a> в GitHub и помогни да направим FetLife достъпен за повече от извратените ни приятели <span class="amp">&amp</span> общности.
-    language_name: Български
+    language_name: "Български"
     sub_header: Hi, hallo, olá, bonjour, ciao, ahoj, opa, szia!
-    title: Избери език
+    title: "Избери език"
   settings_account:
-    2fa_cta: Включи двуетапното удостоверяване
-    2fa_label: Двуетапно удостоверяване
+    2fa_cta: "Включи двуетапното удостоверяване"
+    2fa_label: "Двуетапно удостоверяване"
     anti_pro_tip: <strong>Anti-Pro Tip:</strong> Можеш да <a href="#">deactivate</a> или <a href="#">delete</a> регистрацията си ако наистина искаш, но трима от четири Папи са против това.
-    current_password_label: Текуща парола
-    email_cta: Смени имейл адреса
-    email_label: Имейл
-    email_placeholder: Имейл адрес
-    language_cta: Смени основния език
+    current_password_label: "Текуща парола"
+    email_cta: "Смени имейл адреса"
+    email_label: "Имейл"
+    email_placeholder: "Имейл адрес"
+    language_cta: "Смени основния език"
     language_notice: FetLife все още не е напълно достъпен на езици различни от английски. Ако промениш тази настройка не целия сайт ще бъде преведен.
-    new_password_label: Нова парола
-    nickname_cta: Смени прякора
+    new_password_label: "Нова парола"
+    nickname_cta: "Смени прякора"
     nickname_label: 'Смени прякора си от "JohnBaku" на:'
     nickname_notice: "<strong>Pro Tip:</strong> Седем пъти мери, веднъж режи. Можеш да сменяш прякора си само веднъж на всеки 28 дни. Без право на рекламации."
-    nickname_placeholder: Нов прякор
-    page_title: Смени паролата - настройки
-    password_cta: Смени паролата
-    repeat_password_label: Повтори паролата
-    subtitle: Не натискай голямото червено копче.
-    title: Настройки на профила
+    nickname_placeholder: "Нов прякор"
+    page_title: "Смени паролата - настройки"
+    password_cta: "Смени паролата"
+    repeat_password_label: "Повтори паролата"
+    subtitle: "Не натискай голямото червено копче."
+    title: "Настройки на профила"
   settings_notifications:
-    cta: Смени основния език
-    language_label: Език
+    cta: "Смени основния език"
+    language_label: "Език"
     notice: FetLife все още не е напълно достъпен на езици различни от английски. Ако промениш тази настройка не целия сайт ще бъде преведен.
-    page_title: Език - настройки
-    subtitle: Кой е предпочитаният от теб език?
-    title: Език
+    page_title: "Език - настройки"
+    subtitle: "Кой е предпочитаният от теб език?"
+    title: "Език"
   settings_privacy:
-    blocked_list_subtitle: Списъкът ти с непослушковци.
-    blocked_list_title: Списък с блокирани
-    cb_feed: Позволи не-приятели да ме следват на стените си.
-    cb_fp: Позволи не-поверителните ми публикации да се появяват в Свежо&Перверзно.
-    cb_kp: Позволи не-поверителните ми публикации да се появяват в Извратено&Популярно.
-    content_privacy: Поверителност на съдържанието
-    cta: Запиши настройките за поверителност
-    following: Следване
-    page_title: Настройки за поверителност
-    subtitle: Поднесено така, както го обичаш.
-    title: Поверителност
+    blocked_list_subtitle: "Списъкът ти с непослушковци."
+    blocked_list_title: "Списък с блокирани"
+    cb_feed: "Позволи не-приятели да ме следват на стените си."
+    cb_fp: "Позволи не-поверителните ми публикации да се появяват в Свежо&Перверзно."
+    cb_kp: "Позволи не-поверителните ми публикации да се появяват в Извратено&Популярно."
+    content_privacy: "Поверителност на съдържанието"
+    cta: "Запиши настройките за поверителност"
+    following: "Следване"
+    page_title: "Настройки за поверителност"
+    subtitle: "Поднесено така, както го обичаш."
+    title: "Поверителност"
     warning: "<strong>Изключително важно</strong>: При изключване на следването ще спреш да следваш всички които в момента следват теб. Няма връщане назад. Наистина."
   settings_profile:
-    about_you_label: За теб
+    about_you_label: "За теб"
     add_website: "+ добави друг уебсайт"
-    cta: Промени профила си
-    dob_label: Дата на раждане
-    location_label: Местоположение
-    looking_for_label: Търся
-    page_title: Промени профила
-    subtitle: Личното израстване е хубаво нещо.
-    title: Твоят профил
-    websites_label: Уебсайтове
+    cta: "Промени профила си"
+    dob_label: "Дата на раждане"
+    location_label: "Местоположение"
+    looking_for_label: "Търся"
+    page_title: "Промени профила"
+    subtitle: "Личното израстване е хубаво нещо."
+    title: "Твоят профил"
+    websites_label: "Уебсайтове"
     websites_placeholder: https://fetlife.com
   settings_support:
-    cta: Смени имейл адреса
-    email_label: Смени имейл адреса
-    email_placeholder: Имейл адрес
-    page_title: Смени имейл адреса - настройки
-    subtitle: Просто в случай че си забравиш паролата.
-    title: Смени имейл адреса
+    cta: "Смени имейл адреса"
+    email_label: "Смени имейл адреса"
+    email_placeholder: "Имейл адрес"
+    page_title: "Смени имейл адреса - настройки"
+    subtitle: "Просто в случай че си забравиш паролата."
+    title: "Смени имейл адреса"
   sidebar:
-    about_fetlife: За FetLife
-    ad_stats: Рекламна статистика
-    advertising: Рекламиране
-    androidapp: Инсталирай FetLife за Android
+    about_fetlife: "За FetLife"
+    ad_stats: "Рекламна статистика"
+    advertising: "Рекламиране"
+    androidapp: "Инсталирай FetLife за Android"
     bug_bounty: Bug Bounty
-    caretaking: Надзирателство
-    change_language: Смени езика
-    close: затвори
-    edit_profile: Промени профила
-    edit_settings: Промени настройките
-    events: Събития
-    fetishes: Фетиши
-    following: Следвани
-    fp: Свежо & Перверзно
-    funny_quote: Ако не можеш да прочетеш това ... сигурно ти трябват очила! - Йоан 4:69
-    gift_support: Подари абонамент за FetLife
-    glossary: Тълковен речник
-    groups: Групи
-    guidelines: Правила
-    home: Начало
-    invite_a_friend: Покани приятел (%{count})
-    kp: Извратено & Популярно
-    legalese: Правни въпроси
-    log_out: Излез
-    login: Вход
-    loved_stuff: Харесани
-    need_help: Трябва ти помощ?
-    open_source: Отворен код
-    places: Места
+    caretaking: "Надзирателство"
+    change_language: "Смени езика"
+    close: "затвори"
+    edit_profile: "Промени профила"
+    edit_settings: "Промени настройките"
+    events: "Събития"
+    fetishes: "Фетиши"
+    following: "Следвани"
+    fp: "Свежо & Перверзно"
+    funny_quote: "Ако не можеш да прочетеш това ... сигурно ти трябват очила! - Йоан 4:69"
+    gift_support: "Подари абонамент за FetLife"
+    glossary: "Тълковен речник"
+    groups: "Групи"
+    guidelines: "Правила"
+    home: "Начало"
+    invite_a_friend: "Покани приятел (%{count})"
+    kp: "Извратено & Популярно"
+    legalese: "Правни въпроси"
+    log_out: "Излез"
+    login: "Вход"
+    loved_stuff: "Харесани"
+    need_help: "Трябва ти помощ?"
+    open_source: "Отворен код"
+    places: "Места"
     preservation_requests: Preservation Requests
-    privacy: Поверителност
-    recommendations: Препоръчани
-    signup: Регистрация
+    privacy: "Поверителност"
+    recommendations: "Препоръчани"
+    signup: "Регистрация"
     subscriptions: Subscriptions
-    support: Подкрепи FetLife
-    terms: Условия
-    upload_picture: Качи снимка
-    upload_video: Качи клип
-    view_friends: Виж приятелите
-    whats_new: Какво ново
-    write_post: Напиши публикация
+    support: "Подкрепи FetLife"
+    terms: "Условия"
+    upload_picture: "Качи снимка"
+    upload_video: "Качи клип"
+    view_friends: "Виж приятелите"
+    whats_new: "Какво ново"
+    write_post: "Напиши публикация"
   signup:
-    almost_there: Почти стигнахме!
-    error_bar: Далас, имаме проблем. Превърти надолу за повече информация.
-    error_birthdate: Датата на раждане е задължителна.
-    error_birthdate_too_old: Прекалено възрастни сте.
-    error_birthdate_too_young: Съжалявам, трябва да си поне на 18 години.
-    error_city_missing: Трябва да избереш град.
-    error_country_missing: Трябва да избереш държава.
-    error_email: Имаме проблем с обработването на този имейл адрес. Увери се че няма правописна грешка или опитай с друг адрес.
-    error_email_taken: Имейлът вече е зает.
-    error_gender_required: Трябва да избереш пол.
-    error_nickname: Прякорът е вече зает.
-    error_nickname_bad_word: Прякорът не може да съдържа думата '%{word}'.
-    error_nickname_characters: Прякорът може да съдържа само букви, цифри, тирета и долна черта; никакви интервали.
-    error_nickname_length: Прякорът трябва да е с дължина между 2 и 16 символа.
-    error_nickname_required: Прякорът е задължителен.
-    error_password_range: Паролата трябва да е с дължина между 4 и 100 символа.
-    error_password_required: Паролата е задължителна.
-    error_role_required: Трябва да избереш роля.
-    error_sexual_orientation_required: Трябва да избереш сексуална ориентация.
-    error_state_missing: Трябва да избереш област.
+    almost_there: "Почти стигнахме!"
+    error_bar: "Далас, имаме проблем. Превърти надолу за повече информация."
+    error_birthdate: "Датата на раждане е задължителна."
+    error_birthdate_too_old: "Прекалено възрастни сте."
+    error_birthdate_too_young: "Съжалявам, трябва да си поне на 18 години."
+    error_city_missing: "Трябва да избереш град."
+    error_country_missing: "Трябва да избереш държава."
+    error_email: "Имаме проблем с обработването на този имейл адрес. Увери се че няма правописна грешка или опитай с друг адрес."
+    error_email_taken: "Имейлът вече е зает."
+    error_gender_required: "Трябва да избереш пол."
+    error_nickname: "Прякорът е вече зает."
+    error_nickname_bad_word: "Прякорът не може да съдържа думата '%{word}'."
+    error_nickname_characters: "Прякорът може да съдържа само букви, цифри, тирета и долна черта; никакви интервали."
+    error_nickname_length: "Прякорът трябва да е с дължина между 2 и 16 символа."
+    error_nickname_required: "Прякорът е задължителен."
+    error_password_range: "Паролата трябва да е с дължина между 4 и 100 символа."
+    error_password_required: "Паролата е задължителна."
+    error_role_required: "Трябва да избереш роля."
+    error_sexual_orientation_required: "Трябва да избереш сексуална ориентация."
+    error_state_missing: "Трябва да избереш област."
     footnote: С натискането на горния бутон се съгласяваш да уважаваш и следваш нашите <a class="silver" href="%{guidelines_path}">Правила на общността</a> и <a class="silver" href="%{tou_path}">Условия за ползване</a>&hellip; без право на рекламации.
-    return_to_login: Вече си член? Влез във FetLife
     label:
-      birthdate: Дата на раждане
-      city: Град
-      country: Държава
-      email: Имейл адрес
-      gender: Пол
-      location: Местоположение
-      nickname: Прякор
-      password: Парола
-      role: Роля
-      sexual_orientation: Сексуална ориентация
-      state: Област
-    page_title: Регистрация
-    subtitle: Кажи ни малко за себе си.
+      birthdate: "Дата на раждане"
+      city: "Град"
+      country: "Държава"
+      email: "Имейл адрес"
+      gender: "Пол"
+      location: "Местоположение"
+      nickname: "Прякор"
+      password: "Парола"
+      role: "Роля"
+      sexual_orientation: "Сексуална ориентация"
+      state: "Област"
+    page_title: "Регистрация"
+    return_to_login: "Вече си член? Влез във FetLife"
+    subtitle: "Кажи ни малко за себе си."
     subtitle_invite: "%{name} те покани във FetLife."
-    title: Добре дошли у дома
+    title: "Добре дошли у дома"
   signup_avatar:
     pro_tip: '<strong>Pro Tip</strong>: Ако сте срамежливи и предпочитате да не показвате лицето си, не се притеснявайте да проявите творчество и да ни покажете някоя друга своя страна! Или, ако предпочитате, можете да <a class="silver" href="%{next_step_path}">пропуснете тази стъпка</a> засега.'
     say_cheese: Кажи "зеле"!
-    subtitle: Извратеняците с профилна снимка се забавляват 69 пъти повече!
-    title: Качи профилна снимка
+    subtitle: "Извратеняците с профилна снимка се забавляват 69 пъти повече!"
+    title: "Качи профилна снимка"
   signup_five_strikes:
-    page_title: Втори жълт картон
-    return_to_front: връщане към главната страница
-    subtitle_error: Хм, от съображения за сигурност ще трябва да изчакаш два часа преди да влезеш отново.
-    title: Втори жълт картон
+    page_title: "Втори жълт картон"
+    return_to_front: "връщане към главната страница"
+    subtitle_error: "Хм, от съображения за сигурност ще трябва да изчакаш два часа преди да влезеш отново."
+    title: "Втори жълт картон"
   signup_follow:
-    follow: Следвай
-    next_step: Следваща стъпка
-    subtitle: Следвай извратеняци които предизвикват интереса ти.
-    title: Някой да ти хваща око?
+    follow: "Следвай"
+    next_step: "Следваща стъпка"
+    subtitle: "Следвай извратеняци които предизвикват интереса ти."
+    title: "Някой да ти хваща око?"
   signup_phone:
-    cta: Изпратете ми код за потвърждение
+    cta: "Изпратете ми код за потвърждение"
     error_blocked: "<strong>Извратеният оператор:</strong> За съжаление в момента не позволяваме регистриране с номер на %{carrier_name}."
     error_cant_send: "<strong>Извратеният оператор:</strong> Имаме проблем с изпращането на SMS. Увери се че номера ти започва с кода на твоята държава: +1 за САЩ и Канада, +44 за Великобритания, +61 за Австралия, +31 за Холандия, +49 за Германия, +33 за Франция, и т.н., и че не се опитваш да изпратиш SMS до фиксирания ти телефон."
     error_quota: "<strong>Извратеният оператор:</strong> Хм, можем да изпращаме не повече от 3 SMS-а на 24 часа към даден мобилен номер. Моля, опитай пак."
-    explanation: Знаем че искаме много, но за да поддържаме здрава и жизнена общност трябва да проверим всеки преди да се регистрира. Нещо, което мислим че ще оцениш след като минеш от другата страна.
-    label: Мобилен телефонен номер
-    page_title: Изпрати код за потвърждение
+    explanation: "Знаем че искаме много, но за да поддържаме здрава и жизнена общност трябва да проверим всеки преди да се регистрира. Нещо, което мислим че ще оцениш след като минеш от другата страна."
+    label: "Мобилен телефонен номер"
+    page_title: "Изпрати код за потвърждение"
     pro_tip: "<strong>Pro Tip:</strong> Увери се че номера ти започва с кода на твоята държава: +1 за САЩ и Канада, +44 за Великобритания, +61 за Австралия, +31 за Холандия, +49 за Германия, +33 за Франция, и т.н."
-    subtitle: Еднократен анонимен SMS.
-    title: Време за потвърждение!
+    subtitle: "Еднократен анонимен SMS."
+    title: "Време за потвърждение!"
   signup_verify:
-    cta: Довърши регистрацията & потвърждението
+    cta: "Довърши регистрацията & потвърждението"
     incorrect_code: "<strong>Извратеният оператор:</strong> Ъ&hellip; горният код за потвърждение не изглежда наред. Моля, увери се че горното число съответства на това което получи от нас и опитай пак."
-    label: Код за потвърждение
+    label: "Код за потвърждение"
     notice: Изпратихме кода за потвърждение на <strong>%{phone_number}</strong>. Ако до няколко минути не получиш SMS от нас, <a class="silver" href="%{back_path}">обнови номера си и ще ти изпратим нов код за потвърждение</a>.
-    page_title: Въведи код за потвърждение
+    page_title: "Въведи код за потвърждение"
     placeholder: 6-цифрен код за потвърждение
-    subtitle: Не болеше чак толкова, нали?!?!
-    title: Последна стъпка
+    subtitle: "Не болеше чак толкова, нали?!?!"
+    title: "Последна стъпка"
   subnav:
     feed:
-      activity_feed: Стена
-      activity_feed_short: Стена
+      activity_feed: "Стена"
+      activity_feed_short: "Стена"
       fp: Свежо<span class="a-ampersand">&amp;</span>Перверзно
-      fp_short: Свежо
+      fp_short: "Свежо"
       kp: Извратено<span class="a-ampersand">&amp;</span>Популярно
-      kp_short: Популярно
+      kp_short: "Популярно"
     profile:
-      about: За мен
-      about_short: За мен
-      latest: Последна активност
-      latest_short: Последно
-      pictures: Снимки
-      pictures_short: Снимки
-      videos: Клипове
-      videos_short: Клипове
-      writings: Публикации
-      writings_short: Публикации
+      about: "За мен"
+      about_short: "За мен"
+      latest: "Последна активност"
+      latest_short: "Последно"
+      pictures: "Снимки"
+      pictures_short: "Снимки"
+      videos: "Клипове"
+      videos_short: "Клипове"
+      writings: "Публикации"
+      writings_short: "Публикации"
     settings:
-      account: Регистрация
-      account_short: Регистрация
-      notifications: Известия
-      notifications_short: Известия
-      privacy: Поверителност
-      privacy_short: Поверителност
-      profile: Профил
-      profile_short: Профил
-      support: Подкрепа
-      support_short: Подкрепа
+      account: "Регистрация"
+      account_short: "Регистрация"
+      notifications: "Известия"
+      notifications_short: "Известия"
+      privacy: "Поверителност"
+      privacy_short: "Поверителност"
+      profile: "Профил"
+      profile_short: "Профил"
+      support: "Подкрепа"
+      support_short: "Подкрепа"
   support:
     benefits:
       item_1: A sexy <span>I Support FetLife</span> badge on your profile.

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -190,7 +190,7 @@ de:
   reset_password:
     cta: Setze mein Passwort zurück
     error_confirmation_match: Die Passwort-Wiederholung stimmt nicht mit dem Passwort überein
-    error_password_range: Das Passwort muss zwischen 4 und 100 Zeichen lang sein.
+    error_password_range: Das Passwort muss zwischen 8 und 100 Zeichen lang sein.
     error_token_expired: Das Token zum Zurücksetzen des Passworts ist nicht mehr gültig. Bitte fordere ein neues an.
     error_token_invalid: Das Token zum Zurücksetzen des Passworts ist inkorrekt
     footnote: "<b>Profi-Tipp:</b> Vergiss Dein Passwort nicht."
@@ -322,7 +322,7 @@ de:
     error_nickname_characters: Nickname can only contain letters, numbers, dashes and underscores; no spaces.
     error_nickname_length: Nickname has to be between 2 and 16 characters long.
     error_nickname_required: Der Name ist erforderlich.
-    error_password_range: Das Passwort muss zwischen 4 und 100 Zeichen lang sein.
+    error_password_range: Das Passwort muss zwischen 8 und 100 Zeichen lang sein.
     error_password_required: Das Passwort ist erforderlich.
     error_role_required: Die Rolle muss gewählt werden.
     error_sexual_orientation_required: Die sexuelle Orientierung muss gewählt werden.

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -216,8 +216,8 @@ de:
     language_cta: Aktualisiere Sprachvoreinstellung
     language_notice: FetLife ist noch nicht vollständig in anderen Sprachen als Englisch verfügbar. Wenn Du diese Einstellung änderst, wird nicht die gesamte Seite übersetzt sein.
     new_password_label: Neues Passwort
-    nickname_cta: Ändere den Namen
-    nickname_label: 'Ändere Deinen Namen von „JohnBaku“ nach:'
+    nickname_cta: "Ändere den Namen"
+    nickname_label: "Ändere Deinen Namen von „JohnBaku“ nach:"
     nickname_notice: "<strong>Profi-Tipp:</strong> Denke zweimal nach, bevor Du Dich entscheidest. Du kannst Deinen Namen nur einmal alle 28 Tage ändern. Was gilt, das gilt."
     nickname_placeholder: Neuer Name
     page_title: Passwort Ändern - Einstellungen
@@ -246,7 +246,7 @@ de:
     title: Privatsphäre
     warning: "<strong>Sehr wichtig</strong>: Ausschalten von Folgen wird alle Deine aktuellen Follower entfernen. Es gibt kein Zurück. Echt."
   settings_profile:
-    about_you_label: Über Dich
+    about_you_label: "Über Dich"
     add_website: "+ eine Web-Seite hinzufügen"
     cta: Aktualisiere Dein Profil
     dob_label: Geburtsdatum
@@ -265,7 +265,7 @@ de:
     subtitle: Für den Fall, dass Du Dein Passwort vergisst.
     title: Aktualisiere E-Mail-Adresse
   sidebar:
-    about_fetlife: Über FetLife
+    about_fetlife: "Über FetLife"
     ad_stats: Anzeigen Statistiken
     advertising: Werbung
     androidapp: Installiere FetLife Android App
@@ -328,7 +328,6 @@ de:
     error_sexual_orientation_required: Die sexuelle Orientierung muss gewählt werden.
     error_state_missing: Das Bundesland muss gewählt werden.
     footnote: Indem Du den Knopf oben betätigst, willigst Du ein, unsere <a class="silver" href="%{guidelines_path}">Gemeinschaftsrichtlinien</a> und <a class="silver" href="%{tou_path}">Nutzungsbedingungen</a> zu respektieren und zu befolgen &hellip; keinen Rückzieher.
-    return_to_login: Already a member? Login to FetLife
     label:
       birthdate: Geburtsdatum
       city: Stadt
@@ -342,6 +341,7 @@ de:
       sexual_orientation: Sexuelle Orientierung
       state: Staat/Bundesland
     page_title: Mitglied werden
+    return_to_login: Already a member? Login to FetLife
     subtitle: Erzähl uns ein bisschen über Dich.
     subtitle_invite: "%{name} hat Dich eingeladen, Mitglied bei FetLife zu werden."
     title: Willkommen Zuhause
@@ -389,7 +389,7 @@ de:
       kp: Kinky<span class="a-ampersand">&amp;</span>Beliebt
       kp_short: Beliebt
     profile:
-      about: Über Mich
+      about: "Über Mich"
       about_short: Ich
       latest: Neueste Aktivitäten
       latest_short: Neues
@@ -499,7 +499,7 @@ de:
         title: Bitcoin
       eps:
         extra_info: So einfach und sicher wie die Bezahlung mit Kreditkarte. Für die mit einem EPS-fähigen Konto in Österreich.
-        title: Österreichische Bezahloption (EPS)
+        title: "Österreichische Bezahloption (EPS)"
       giropay:
         extra_info: So einfach und sicher wie die Bezahlung mit Kreditkarte. Für die mit einem giropay-fähigen Konto in Deutschland.
         title: Deutsche giropay Bezahloption

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -190,7 +190,7 @@ en:
   reset_password:
     cta: Reset My Password
     error_confirmation_match: Password confirmation doesn't match Password
-    error_password_range: Password needs to be between 4 and 100 characters
+    error_password_range: Password needs to be between 8 and 100 characters
     error_token_expired: Reset password token has expired, please request a new one
     error_token_invalid: Reset password token is invalid
     footnote: "<b>Pro Tip:</b> Remember your password."
@@ -322,7 +322,7 @@ en:
     error_nickname_characters: Nickname can only contain letters, numbers, dashes and underscores; no spaces.
     error_nickname_length: Nickname has to be between 2 and 16 characters long.
     error_nickname_required: Nickname is required.
-    error_password_range: Password needs to be between 4 and 100 characters.
+    error_password_range: Password needs to be between 8 and 100 characters.
     error_password_required: Password is required.
     error_role_required: Role has to be selected.
     error_sexual_orientation_required: Sexual Orientation has to be selected.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -328,7 +328,6 @@ en:
     error_sexual_orientation_required: Sexual Orientation has to be selected.
     error_state_missing: State/Province has to be selected.
     footnote: By clicking the button above you agree to respect and follow our <a class="silver" href="%{guidelines_path}">Community Guidelines</a> and <a class="silver" href="%{tou_path}">Terms of Use</a>&hellip; no take backs.
-    return_to_login: Already a member? Login to FetLife
     label:
       birthdate: Birthdate
       city: City
@@ -342,6 +341,7 @@ en:
       sexual_orientation: Sexual Orientation
       state: State/Province
     page_title: Join
+    return_to_login: Already a member? Login to FetLife
     subtitle: Tell us a little bit about yourself.
     subtitle_invite: "%{name} invited you to join FetLife."
     title: Welcome Home

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -190,7 +190,7 @@ es:
   reset_password:
     cta: Restablecer mi contraseña
     error_confirmation_match: La confirmación de contraseña no coincide con la contraseña
-    error_password_range: La contraseña debe tener entre 4 y 100 caracteres
+    error_password_range: La contraseña debe tener entre 8 y 100 caracteres
     error_token_expired: El token de contraseña de restablecimiento ha caducado, solicite uno nuevo
     error_token_invalid: El token de contraseña de restablecimiento no es válido
     footnote: "<b>Consejo Pro:</b> Recuerde su contraseña."
@@ -322,7 +322,7 @@ es:
     error_nickname_characters: El apodo solo puede tener letras, números, guiones y guiones bajos; sin espacios.
     error_nickname_length: El apodo debe tener entre 2 y 16 caracteres de largo.
     error_nickname_required: Se requiere su apodo.
-    error_password_range: La contraseña debe tener entre 4 y 100 caracteres.
+    error_password_range: La contraseña debe tener entre 8 y 100 caracteres.
     error_password_required: Se requiere su contraseña.
     error_role_required: Se requiere su rol.
     error_sexual_orientation_required: Se requiere su orientación sexual.

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -93,7 +93,7 @@ es:
     tab_email: Correo electrónico
     tab_mobile: Móvil
   guidelines:
-    last_updated: 'Última actualización:'
+    last_updated: "Última actualización:"
     subnav:
       community: Comunidad
       content: Contenido
@@ -328,7 +328,6 @@ es:
     error_sexual_orientation_required: Se requiere su orientación sexual.
     error_state_missing: Debe seleccionar un Estado/Provincia.
     footnote: Al hacer clic en el botón de arriba se compromete a respetar y seguir nuestras <a class="silver" href="%{guidelines_path}"> Normas de la comunidad</a> y<a class="silver" href="%{tou_path}"> Términos de Uso</a> &hellip; no se admiten devoluciones.
-    return_to_login: ¿Ya es usted miembro? Inicie sesión en FetLife
     label:
       birthdate: Fecha de Nacimiento
       city: Ciudad
@@ -342,6 +341,7 @@ es:
       sexual_orientation: Orientación Sexual
       state: Estado/Provincia
     page_title: Unirse
+    return_to_login: "¿Ya es usted miembro? Inicie sesión en FetLife"
     subtitle: Cuéntenos un poco sobre Ud.
     subtitle_invite: "%{name} le invitó a unirse a FetLife."
     title: Bienvenido a casa
@@ -379,7 +379,7 @@ es:
     page_title: Ingrese el Código de Verificación
     placeholder: Código de verificaión de 6 dígitos
     subtitle: "¡¿A que no fue para tanto?!"
-    title: Último Paso
+    title: "Último Paso"
   subnav:
     feed:
       activity_feed: Feed de actividad

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -19,7 +19,7 @@ fr:
     north_america: Amérique du Nord
     one_love: Un amour, une vie, et beaucoup de kink !
     snail_mail: Courrier papier
-    sub_header: À ne pas confondre avec les spartiates
+    sub_header: "À ne pas confondre avec les spartiates"
     title: Nous. Sommes. FetLife !
   components:
     step: Step
@@ -45,14 +45,14 @@ fr:
     follow: Suivre
     following: Suivi
   footer:
-    about: À propos
+    about: "À propos"
     help: Aide
     privacy: Privacy
   forgot_password:
     email:
       cta: Envoie-moi un email avec instructions
       error_forgot_email: Email address is required.
-      error_invalid_email: Ça ne ressemble pas à une adresse mail valide. Veuillez la relire et la re-soumettre.
+      error_invalid_email: "Ça ne ressemble pas à une adresse mail valide. Veuillez la relire et la re-soumettre."
       error_quota: Nous ne pouvons envoyer que deux emails par heure à une même adresse. Veuillez revérifier que notre email n’a pas fini dans votre dossier spam. Si vous ne trouvez rien dans votre pourriel je vous recommande d’utiliser l’une des autres méthodes ci-dessus pour revenir à votre compte.
       placeholder: Adresse mail
       step1:
@@ -88,7 +88,7 @@ fr:
         subtitle: Nous vous avons “peut-être” envoyé un texto.
         title: Entrez le code de vérification
       warning: "<strong>Avertissement du Ministère de la Santé :</strong> Pour des raisons de sécurité, nous ne pouvons pas vous dire si un numéro de mobile existe ou non dans notre base de données. Si vous ne recevez pas de texto de nous, il est probable que nous n’avons pas de compte associé à ce numéro de mobile."
-    next_step: étape suivante
+    next_step: "étape suivante"
     return_to_login: retour au login
     tab_email: Email
     tab_mobile: Mobile
@@ -111,7 +111,7 @@ fr:
       email: Adresse mail
       friends_email: Addresse mail de ton ami
       friends_email_sub: "%{count} invitation⋅s restante⋅s"
-    next_step: étape suivante
+    next_step: "étape suivante"
     return_to_feed: retour à feed
     subtitle_step1:
       one: Vous avez 1 invitation restante.
@@ -166,7 +166,7 @@ fr:
       one: 1 vidéo
       other: "%{count_with_delimiter} vidéos"
   nav:
-    events: Évènements
+    events: "Évènements"
     explore: Explorer
     fetishes: Fétiches
     groups: Groupes
@@ -246,12 +246,12 @@ fr:
     title: Confidentialité
     warning: "<strong>Extrêmement Important</strong> : Désactiver le suivi vous retirera des listes de tous ceux qui vous suivent actuellement. Sans retour. Sérieusement."
   settings_profile:
-    about_you_label: À propos de vous
+    about_you_label: "À propos de vous"
     add_website: "+ ajouter un autre site web"
     cta: Mettre à jour votre profil
     dob_label: Date de naissance
     location_label: Position
-    looking_for_label: À la recherche de
+    looking_for_label: "À la recherche de"
     page_title: Mettre à jour le profil
     subtitle: Le développement personnel est une bonne chose.
     title: Votre profil
@@ -265,7 +265,7 @@ fr:
     subtitle: Au cas où vous oublieriez votre mot de passe.
     title: Mettre à jour l’adresse mail
   sidebar:
-    about_fetlife: À propos de Fetlife
+    about_fetlife: "À propos de Fetlife"
     ad_stats: Statistiques d’annonces
     advertising: Publicité
     androidapp: Installer l’app Android de FetLife
@@ -275,7 +275,7 @@ fr:
     close: fermer
     edit_profile: Modifier profil
     edit_settings: Modifier paramètres
-    events: Événements
+    events: "Événements"
     fetishes: Fétiches
     following: Suivi
     fp: Fresh & Pervy
@@ -305,7 +305,7 @@ fr:
     upload_video: Envoyer vidéo
     view_friends: Voir ami⋅e⋅s
     whats_new: Quoi de neuf
-    write_post: Écrire un post
+    write_post: "Écrire un post"
   signup:
     almost_there: Presque arrivé⋅e !
     error_bar: Dallas, nous avons un problème. Faites défiler vers le bas pour plus d’informations.
@@ -328,7 +328,6 @@ fr:
     error_sexual_orientation_required: L’orientation sexuelle doit être sélectionnée.
     error_state_missing: L’état/la province doit être sélectionné⋅e.
     footnote: En cliquant sur le bouton ci-dessus vous acceptez de respecter et de suivre nos <a class="silver" href="%{guidelines_path}">Lignes directrices communautaires</a> et nos <a class="silver" href="%{tou_path}">Conditions d’utilisation</a>&hellip; Sans retour.
-    return_to_login: Already a member? Login to FetLife
     label:
       birthdate: Date de naissance
       city: Ville
@@ -340,8 +339,9 @@ fr:
       password: Mot de passe
       role: Rôle
       sexual_orientation: Orientation sexuelle
-      state: État/Province
+      state: "État/Province"
     page_title: Rejoindre
+    return_to_login: Already a member? Login to FetLife
     subtitle: Parlez-nous un peu de vous.
     subtitle_invite: "%{name} vous a invité⋅e à rejoindre Fetlife."
     title: Bienvenue à la maison
@@ -357,7 +357,7 @@ fr:
     title: Règle des cinq essais
   signup_follow:
     follow: Suivre
-    next_step: Étape suivante
+    next_step: "Étape suivante"
     subtitle: Suivre des kinksters qui piquent votre intérêt.
     title: Quelqu’un⋅e attire votre attention ?
   signup_phone:
@@ -389,16 +389,16 @@ fr:
       kp: Kinky<span class="a-ampersand">&amp;</span>Popular
       kp_short: Populaire
     profile:
-      about: À propos de moi
-      about_short: À propos
+      about: "À propos de moi"
+      about_short: "À propos"
       latest: Activité récente
       latest_short: Récent
       pictures: Photos
       pictures_short: Pics
       videos: Vidéos
       videos_short: Vids
-      writings: Écrits
-      writings_short: Écrits
+      writings: "Écrits"
+      writings_short: "Écrits"
     settings:
       account: Compte
       account_short: Compte
@@ -515,8 +515,8 @@ fr:
         title: Courrier physique
       more_options: Afficher plus d’options
       paygarden:
-        extra_info: Échange de cartes cadeau de plus de 100 marques, y compris Starbucks, Best Buy, Target, Walmart, Home Depot, Build-A-Bear, et Toys'R'Us.
-        title: Échange de cartes cadeau de grandes enseignes
+        extra_info: "Échange de cartes cadeau de plus de 100 marques, y compris Starbucks, Best Buy, Target, Walmart, Home Depot, Build-A-Bear, et Toys'R'Us."
+        title: "Échange de cartes cadeau de grandes enseignes"
       paysafe:
         extra_info: Vous pouvez acheter une Paysafecard dans plus de 500 000 points de vente, situés dans 43 pays à travers le monde, et l’utiliser pour supporter FetLife.
         title: Paysafecard pré-payée
@@ -543,7 +543,7 @@ fr:
       60_info: "$5/mois"
       60_title: "$60 pour 12 mois"
       return_info: Garantie de remboursement sans condition durant 7 jours
-      title: À quel point aimez-vous FetLife ?
+      title: "À quel point aimez-vous FetLife ?"
     step2_paygarden:
       confirm: J’ai une carte cadeau que je veux échanger contre le support
       list_footer: et <a href='%{link}'>des centaines d’autres grandes enseignes.</a>
@@ -572,12 +572,12 @@ fr:
       routing_number_placeholder: Numéro de routage bancaire
       routing_number_sub_label: nombre à 9 chiffres
       secure: Aussi sûr que Fort Knox, et nous n’enregistrons aucune de vos données personnelles.
-      state_label: État
-      state_placeholder: État
+      state_label: "État"
+      state_placeholder: "État"
       state_sub_label: associé au compte bancaire
       title: Paiement en ligne / Virement bancaire
       type_checking: Payer
-      type_savings: Économies
+      type_savings: "Économies"
       zip_label: Code ZIP
       zip_sub_label: associé au compte bancaire
     step3_bitcoin:
@@ -744,7 +744,7 @@ fr:
       gift_affirm: Vous êtes le⋅la meilleur⋅e !
       gift_cta_profile: Visiter le profil de %{nickname}
       gift_next_body: Pendant que vous lisez ceci, nous sommes en train de donner son support à <a href="%{link}">%{nickname}</a>, et de le⋅la notifier par mail de votre généreux cadeau.
-      gift_next_title: Étapes suivantes ?
+      gift_next_title: "Étapes suivantes ?"
       page_title: Merci !
       questions_body: Si vous avez des questions, n’hésitez pas à nous envoyer un mail à <a href='mailto:support@fetlife.com'>support@fetlife.com</a>.
       questions_title: Des questions ?
@@ -755,7 +755,7 @@ fr:
       next_steps_final_default: nous allons l’attacher à votre profil.
       next_steps_final_gift: nous allons l’attacher au profil de %{nickname}.
       next_steps_first: Cela peut <span>prendre une heure ou deux</span> avant que nous ne recevions votre Interac e-Transfer, mais dès que nous l’avons
-      next_steps_title: 'Étapes suivantes :'
+      next_steps_title: "Étapes suivantes :"
       page_title: Merci <span class='baskerville i'>&amp;</span> Étapes suivantes
       tab_title: Merci & Étapes suivantes
       thank_you: Merci !

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -190,7 +190,7 @@ fr:
   reset_password:
     cta: Réinitialiser mon mot de passe
     error_confirmation_match: Le mot de passe de confirmation ne correspond pas au mot de passe
-    error_password_range: Le mot de passe doit être compris entre 4 et 100 caractères
+    error_password_range: Le mot de passe doit être compris entre 8 et 100 caractères
     error_token_expired: Le jeton de réinitialisation du mot de passe a expiré, veuillez en demander un nouveau
     error_token_invalid: Le jeton de réinitialisation du mot de passe n’est pas valide
     footnote: "<b>Astuce de pro :</b> Rappelez-vous de votre mot de passe."
@@ -322,7 +322,7 @@ fr:
     error_nickname_characters: Nickname can only contain letters, numbers, dashes and underscores; no spaces.
     error_nickname_length: Nickname has to be between 2 and 16 characters long.
     error_nickname_required: Le pseudo est obligatoire.
-    error_password_range: Le mot de passe doit être compris entre 4 et 100 caractères.
+    error_password_range: Le mot de passe doit être compris entre 8 et 100 caractères.
     error_password_required: Le mot de passe est obligatoire.
     error_role_required: Le rôle doit être sélectionné.
     error_sexual_orientation_required: L’orientation sexuelle doit être sélectionnée.

--- a/locales/gr.yml
+++ b/locales/gr.yml
@@ -2,34 +2,34 @@
 gr:
   2fa:
     5strike:
-      return: επιστρέψτε στην αρχική σελίδα
-      subtitle: Για λόγους ασφαλείας, θα πρέπει να περιμένετε δύο ώρες πριν να μπορέσετε να συνδεθείτε ξανά.
+      return: "επιστρέψτε στην αρχική σελίδα"
+      subtitle: "Για λόγους ασφαλείας, θα πρέπει να περιμένετε δύο ώρες πριν να μπορέσετε να συνδεθείτε ξανά."
       title: Five Strike Rule
-    cta: Εγώ είμαι, αφήστε με να μπω!
+    cta: "Εγώ είμαι, αφήστε με να μπω!"
     error: "<strong>Διεστραμμένος Χειριστής:</strong> Ωχ... ο κωδικός πιστοποίησης φαίνεται λάθος. Παρακαλώ βεβαιωθείτε ότι ο αριθμός ταιριάζει με αυτόν που σας στείλαμε και προσπαθήστε ξανά."
-    label: κωδικός πιστοποίησης
+    label: "κωδικός πιστοποίησης"
     page_title: 2-Factor πιστοποίηση
     subtitle: 2-Factor me baby!
-    title: Μυστικός κωδικός
+    title: "Μυστικός κωδικός"
   about:
-    contact_info: Στοιχεία Επικοινωνίας
+    contact_info: "Στοιχεία Επικοινωνίας"
     email_us: Στείλτε μας email στο <a href="mailto:support@fetlife.com">support@fetlife.com</a> και εμείς θα επικοινωνήσουμε μαζί σας σύντομα!
-    europe: Ευρώπη
-    got_question: Έχετε κάποια ερώτηση; Χρειαζόσαστε βοήθεια;
-    north_america: Βόρεια Αμερική
-    one_love: Μία αγάπη, μία ζωή, και μπόλικο kink.
-    snail_mail: Αργό Ταχυδρομείο
-    sub_header: Μην το μπερδεύετε με τους Σπαρτιάτες.
-    title: Είμαστε το FetLife!
+    europe: "Ευρώπη"
+    got_question: "Έχετε κάποια ερώτηση; Χρειαζόσαστε βοήθεια;"
+    north_america: "Βόρεια Αμερική"
+    one_love: "Μία αγάπη, μία ζωή, και μπόλικο kink."
+    snail_mail: "Αργό Ταχυδρομείο"
+    sub_header: "Μην το μπερδεύετε με τους Σπαρτιάτες."
+    title: "Είμαστε το FetLife!"
   components:
     step: Step
   feed:
-    comment: Σχόλιο
+    comment: "Σχόλιο"
     comments_count:
       one: 1 σχόλιο
       other: "%{count_with_delimiter} Σχόλια"
     composer:
-      button: Πες Το
+      button: "Πες Το"
       placeholder: Tι Λέτε?
     love: Aγαπώ
     loved_hover: Heart Breaker! :-(
@@ -37,38 +37,38 @@ gr:
       one: 1 αγάπη
       other: "%{count_with_delimiter} Αγάπες"
     modal:
-      close: Κλείσιμο
-      more: Περισσότερα
+      close: "Κλείσιμο"
+      more: "Περισσότερα"
       reply: Aπάντηση
-    title: Ροή
+    title: "Ροή"
   following:
-    follow: Ακολουθήστε
-    following: Ακολουθώ
+    follow: "Ακολουθήστε"
+    following: "Ακολουθώ"
   footer:
-    about: Σχετικά
-    help: Βοήθεια
+    about: "Σχετικά"
+    help: "Βοήθεια"
     privacy: Privacy
   forgot_password:
     email:
-      cta: Στείλτε μου Email με οδηγίες
+      cta: "Στείλτε μου Email με οδηγίες"
       error_forgot_email: Email address is required.
-      error_invalid_email: Δεν μοιάζει με έγκυρο email. Παρακαλώ ελέγξτε ξανά και υποβάλετε εκ νέου.
-      error_quota: Μπορούμε να στείλουμε μόνο δύο emails ανά ώρα σε μία συγκεκριμένη διεύθυνση email. Παρακαλώ βεβαιωθείτε ότι το email μας δεν βρέθηκε στον φάκελο της ανεπιθύμητης αλληλογραφίας. Αν δεν μπορείτε να το βρείτε σε αυτό τον φάκελο, συνιστούμε να χρησιμοποιήσετε μία από τις άλλες μεθόδους για να ξαναμπείτε στο λογαριασμό σας.
-      placeholder: Διεύθυνση Email
+      error_invalid_email: "Δεν μοιάζει με έγκυρο email. Παρακαλώ ελέγξτε ξανά και υποβάλετε εκ νέου."
+      error_quota: "Μπορούμε να στείλουμε μόνο δύο emails ανά ώρα σε μία συγκεκριμένη διεύθυνση email. Παρακαλώ βεβαιωθείτε ότι το email μας δεν βρέθηκε στον φάκελο της ανεπιθύμητης αλληλογραφίας. Αν δεν μπορείτε να το βρείτε σε αυτό τον φάκελο, συνιστούμε να χρησιμοποιήσετε μία από τις άλλες μεθόδους για να ξαναμπείτε στο λογαριασμό σας."
+      placeholder: "Διεύθυνση Email"
       step1:
-        page_title: Επαναφέρετε τον κωδικό μέσω Email
-        subtitle: Επιτρέψτε μου να σας βοηθήσω με αυτό.
-        title: Ξεχάσατε τον κωδικό πρόσβασης;
+        page_title: "Επαναφέρετε τον κωδικό μέσω Email"
+        subtitle: "Επιτρέψτε μου να σας βοηθήσω με αυτό."
+        title: "Ξεχάσατε τον κωδικό πρόσβασης;"
       step2:
         page_title: '"Μπορεί" να εχέτε αλληλογραφία'
-        subtitle: Αν υπάρχει προφίλ συνδεδεμένο με αυτό το email <span class='fw5'>%{given_email}</span> τότε σας έχουμε στείλει οδηγίες για το πώς να επαναφέρετε τον κωδικό πρόσβασης.
+        subtitle: "Αν υπάρχει προφίλ συνδεδεμένο με αυτό το email <span class='fw5'>%{given_email}</span> τότε σας έχουμε στείλει οδηγίες για το πώς να επαναφέρετε τον κωδικό πρόσβασης."
         title: '"Μπορεί" να έχετε Αλληλογραφία!'
-      update_email: Ενημέρωση διεύθυνσης email
+      update_email: "Ενημέρωση διεύθυνσης email"
       warning: "<strong>Ο Γενικός Χειρούργος προειδοποιεί:</strong> Για λόγους ασφάλειας, δεν μπορούμε να πούμε αν μια διεύθυνση email υπάρχει στη βάση δεδομένων μας ή όχι. Αν δεν λάβατε email από εμάς, είναι πολύ πιθανό να μην έχουμε λογαριασμό συνδεδεμένο με αυτή τη διεύθυνση email."
     mobile:
       5strike:
-        return: Επιστρέψτε στην αρχική σελίδα
-        subtitle: Για λόγους ασφαλείας, θα πρέπει να περιμένετε δύο ώρες πριν να μπορέσετε να συνδεθείτε ξανά.
+        return: "Επιστρέψτε στην αρχική σελίδα"
+        subtitle: "Για λόγους ασφαλείας, θα πρέπει να περιμένετε δύο ώρες πριν να μπορέσετε να συνδεθείτε ξανά."
         title: Five Strike Rule
       cta: Στείλε μου "Μήνυμα Κειμένου"?
       error_country_code: "<strong>Διεστραμμένος Χειριστής:</strong> Βεβαιωθείτε ότι αρχίσατε την εισαγωγή του αριθμού σας με τον κωδικό της χώρας σας: +1 για την Αμερική και τον Καναδά, +44 για το Ηνωμένο Βασίλειο, +61 για την Αυστραλία, +31 για την Ολλανδία, +49 για την Γερμανία, +33 για την Γαλλία, κτλ."
@@ -76,85 +76,85 @@ gr:
       pro_tip: "<strong>Pro Tip:</strong> Βεβαιώσου να αρχίζει ο αριθμός σου με τον κωδικό της χώρας: +1 για την Αμερική και Καναδά, +44 για το UK, +61 για Αυστραλία, +31 για Ολλανδία, +49 για Γερμανία, +33 για Γαλλία, κτλ."
       step1:
         page_title: Eπαναφέρετε τον κωδικό μέσω μηνύματος κειμένου
-        subtitle: Επιτρέψτε μου να σας βοηθήσω με αυτό.
-        title: Ξεχάσατε τον κωδικό πρόσβασης?
+        subtitle: "Επιτρέψτε μου να σας βοηθήσω με αυτό."
+        title: "Ξεχάσατε τον κωδικό πρόσβασης?"
       step2:
-        cta: Επαληθεύστε το ποιος είστε
+        cta: "Επαληθεύστε το ποιος είστε"
         error_code_match: "<strong>Διεστραμμένος Χειριστής:</strong> Ο κωδικός επαλήθευσης που εισαγάγατε είναι λάθος. Βεβαιωθείτε ότι ο αριθμός που εισάγατε είναι ο ίδιος αριθμός που λάβατε από μας και παρακαλώ προσπαθήστε ξανά. Αυτό είναι μια καταγραφή."
         inexisting_number: Αν μετά από δύο λεπτά δεν λάβετε μήνυμα από εμάς, ο λόγος είναι ότι δεν έχουμε προφίλ συνδεδεμένο με τον αριθμό σας. Σας προτείνουμε να δοκιμάσετε είτε την <a href="%{forgot_password_email_path}">Επαναφορά του κωδικό πρόσβασης χρησιμοποιόντας άλλη μέθοδο</a> είτε την <a href="%{signup_path}"> δημιουργία νέου προφίλ στο FetLife</a>.
-        label: Κωδικός Επιβεβαίωσης
-        page_title: Εισάγετε κωδικό επιβεβαίωσης
+        label: "Κωδικός Επιβεβαίωσης"
+        page_title: "Εισάγετε κωδικό επιβεβαίωσης"
         placeholder: 6-ψήφιος Κωδικός Επιβεβαίωσης
         subtitle: '"Μπορεί" να σας στείλαμε μήνυμα κειμένου.'
-        title: Εισάγετε τον Κωδικό Επιβεβαίωσης
+        title: "Εισάγετε τον Κωδικό Επιβεβαίωσης"
       warning: "<strong>Ο Γενικός Χειρούργος προειδοποιεί:</strong> Για λόγους ασφάλειας, δεν μπορούμε να πούμε αν ένας αριθμός κινητού τηλεφώνου υπάρχει στη βάση δεδομένων μας ή όχι Αν δεν λάβατε μήνυμα κειμένου από εμάς, είναι πολύ πιθανό να μην έχουμε λογαριασμό συνδεδεμένο με αυτό τον αριθμό."
-    next_step: επόμενο βήμα
-    return_to_login: επιστροφή στη σελίδα σύνδεσης
+    next_step: "επόμενο βήμα"
+    return_to_login: "επιστροφή στη σελίδα σύνδεσης"
     tab_email: Email
-    tab_mobile: Κινητό
+    tab_mobile: "Κινητό"
   guidelines:
-    last_updated: 'Πρόσφατη Ενημέρωση:'
+    last_updated: "Πρόσφατη Ενημέρωση:"
     subnav:
-      community: Κοινότητα
-      content: Περιεχόμενα
-      group_leader: Αρχηγός Ομάδας
+      community: "Κοινότητα"
+      content: "Περιεχόμενα"
+      group_leader: "Αρχηγός Ομάδας"
     title: Kατευθυντήριες Γραμμές
   invite_a_friend:
-    cancel_button: ακύρωση
+    cancel_button: "ακύρωση"
     cancel_notice: H πρόσκληση στο %{email} ακυρώθηκε.
-    cta: Προσκαλέστε ένα φίλο στο FetLife
-    error: Αντιμετωπίσαμε προβλήματα με την αποστολή πρόσκλησης σε αυτή τη διεύθυνση email. Συνιστούμε να ελέγξετε την ορθογραφία ή να δοκιμάσετε κάποια άλλη διέυθυνση email.
+    cta: "Προσκαλέστε ένα φίλο στο FetLife"
+    error: "Αντιμετωπίσαμε προβλήματα με την αποστολή πρόσκλησης σε αυτή τη διεύθυνση email. Συνιστούμε να ελέγξετε την ορθογραφία ή να δοκιμάσετε κάποια άλλη διέυθυνση email."
     error_forgot_email: Email address is required.
-    invitations_accepted: Πρόσκληση Αποδέκτηκε
-    invitations_sent: Πρόσκληση Στάλθηκε
+    invitations_accepted: "Πρόσκληση Αποδέκτηκε"
+    invitations_sent: "Πρόσκληση Στάλθηκε"
     labels:
-      email: Διεύθυνση Email
-      friends_email: Διεύθυνση Email φίλου
+      email: "Διεύθυνση Email"
+      friends_email: "Διεύθυνση Email φίλου"
       friends_email_sub: "%{count} invitations remaining"
-    next_step: επόμενο βήμα
-    return_to_feed: επιστροφή στη ροή
+    next_step: "επόμενο βήμα"
+    return_to_feed: "επιστροφή στη ροή"
     subtitle_step1:
-      one: Σας έχει απομείνει 1 πρόσκληση.
-      other: Σας έχουν απομέινει %{count_with_delimiter} προσκλήσεις.
-    subtitle_step2: Στείλαμε μια πρόσκληση από εσάς στο %{email}.
-    title_step1: Καλέστε ένα Φίλο
-    title_step2: Πρόσκληση Στάλθηκε
-    view_invitations: Προβολή των προσκλήσεών σας
+      one: "Σας έχει απομείνει 1 πρόσκληση."
+      other: "Σας έχουν απομέινει %{count_with_delimiter} προσκλήσεις."
+    subtitle_step2: "Στείλαμε μια πρόσκληση από εσάς στο %{email}."
+    title_step1: "Καλέστε ένα Φίλο"
+    title_step2: "Πρόσκληση Στάλθηκε"
+    view_invitations: "Προβολή των προσκλήσεών σας"
   landing_page:
     footer: <span class="fw5">%{member_count} Τα μέλη</span><span>  μοιράζονται </span><span class="fw5">%{picture_count} εικόνες</span><span> και </span><span class="fw5">%{video_count} βίντεο</span><span>, συμμετέχουν σε </span><span class="fw5">%{discussion_count} συζητήσεις</span><span> σε </span><span class="fw5">%{group_count} ομάδες</span><span>, πηγαίνουν σε </span><span class="fw5">%{event_count} επερχόμενες εκδηλώσεις</span><span> και διαβάζουν </span><span class="fw5">%{post_count} blog posts</span><span>. </span><span><i>Kinky παράδεισος!</i></span>
-    login_button: Σύνδεση στο FetLife
-    signup_button: Εγγραφή στο FetLife
-    subtitle: Σαν το Facebook, αλλά οργανωμένο από kinksters σαν εσένα και εμένα. Πιστεύουμε ότι έχει πιο πολύ πλάκα έτσι. Δεν νομίζετε;
-    title: Το FetLife είναι ένα κοινωνικό δίκτυο για την BDSM, Φετίχ & Kinky κοινότητα.
+    login_button: "Σύνδεση στο FetLife"
+    signup_button: "Εγγραφή στο FetLife"
+    subtitle: "Σαν το Facebook, αλλά οργανωμένο από kinksters σαν εσένα και εμένα. Πιστεύουμε ότι έχει πιο πολύ πλάκα έτσι. Δεν νομίζετε;"
+    title: "Το FetLife είναι ένα κοινωνικό δίκτυο για την BDSM, Φετίχ & Kinky κοινότητα."
   legalese:
     subnav:
       2257_exempt: 2257 Εξαίρεση
       legal_requests: Legal Requests
-      privacy: Πολιτική Προστασίας Προσωπικών Δεδομένων
-      terms: Όροι χρήσης
-    title: Νομικός
+      privacy: "Πολιτική Προστασίας Προσωπικών Δεδομένων"
+      terms: "Όροι χρήσης"
+    title: "Νομικός"
   lockout:
-    subtitle: Έπεσες πάνω στο σύστημα ασφαλείας.
+    subtitle: "Έπεσες πάνω στο σύστημα ασφαλείας."
     title: Security, Security, Security!
   login:
-    button: Σύνδεση στο FetLife
+    button: "Σύνδεση στο FetLife"
     error_flash: Παρακαλώ επικοινωνωνήστε με το <a href="mailto:support@fetlife.com">support@fetlife.com</a> για να σας βοηθήσουμε να ξανά μπείτε.
-    error_login_blank: Το Login δεν μπορεί να είναι κενό.
-    error_not_authenticated: Συγγνώμη, θα πρέπει να είστε συνδεδεμένοι για να φθάσετε σε αυτή τη σελίδα. Αν δεν είστε ήδη μέλος χρειάζεται λιγότερο από ένα λεπτό να κάνετε εγγραφή.
-    error_not_found: Χμμμ, δεν ήμασταν σε θέση να σας βρούμε. Είστε βέβαιοι ότι έχετε εισαγάγει το ψευδώνυμο και τον κωδικό πρόσβασής σας σωστά? (Οι κωδικοί πρόσβασης διακρίνουν πεζά-ΚΕΦΑΛΑΊΑ)
-    error_password_blank: Ο κωδικός πρόσβασης δεν μπορεί να είναι κενός.
-    forgot_info: Ξεχάσατε τα στοιχεία σύνδεσης?
+    error_login_blank: "Το Login δεν μπορεί να είναι κενό."
+    error_not_authenticated: "Συγγνώμη, θα πρέπει να είστε συνδεδεμένοι για να φθάσετε σε αυτή τη σελίδα. Αν δεν είστε ήδη μέλος χρειάζεται λιγότερο από ένα λεπτό να κάνετε εγγραφή."
+    error_not_found: "Χμμμ, δεν ήμασταν σε θέση να σας βρούμε. Είστε βέβαιοι ότι έχετε εισαγάγει το ψευδώνυμο και τον κωδικό πρόσβασής σας σωστά? (Οι κωδικοί πρόσβασης διακρίνουν πεζά-ΚΕΦΑΛΑΊΑ)"
+    error_password_blank: "Ο κωδικός πρόσβασης δεν μπορεί να είναι κενός."
+    forgot_info: "Ξεχάσατε τα στοιχεία σύνδεσης?"
     labels:
-      nickname: Ψευδώνυμο ή Email
-      password: Κωδικός Πρόσβασης
-      remember_me: Να με θυμάστε, θα επιστρέψω.
-    not_a_member: Δεν είστε ακόμη μέλος; Εγγραφείτε στο FetLife
-    subtitle: Μας λείψατε… Πολύ!
-    title: Καλωσόρισες σπίτι
+      nickname: "Ψευδώνυμο ή Email"
+      password: "Κωδικός Πρόσβασης"
+      remember_me: "Να με θυμάστε, θα επιστρέψω."
+    not_a_member: "Δεν είστε ακόμη μέλος; Εγγραφείτε στο FetLife"
+    subtitle: "Μας λείψατε… Πολύ!"
+    title: "Καλωσόρισες σπίτι"
   logout:
-    log_in: συνδεθείτε ξανά
-    subtitle: Φροντίστε να έρθετε πίσω και να μας δείτε σύντομα.
-    title: Θα μας λείψετε!
+    log_in: "συνδεθείτε ξανά"
+    subtitle: "Φροντίστε να έρθετε πίσω και να μας δείτε σύντομα."
+    title: "Θα μας λείψετε!"
   member_stats:
     pics:
       one: 1 εικόνα
@@ -166,250 +166,250 @@ gr:
       one: 1 βίντεο
       other: "%{count_with_delimiter} βίντεο"
   nav:
-    events: Εκδηλώσεις
-    explore: Εξερεύνηση
-    fetishes: Φετίχ
-    groups: Ομάδες
-    home: Αρχική σελίδα
-    places: Μέρη
-    search_placeholder: Αναζήτηση
+    events: "Εκδηλώσεις"
+    explore: "Εξερεύνηση"
+    fetishes: "Φετίχ"
+    groups: "Ομάδες"
+    home: "Αρχική σελίδα"
+    places: "Μέρη"
+    search_placeholder: "Αναζήτηση"
   page_break:
     of: of
   profile:
-    about_title: Λίστα φίλων
-    pictures_title: Εικόνες
-    videos_title: Βίντεο
+    about_title: "Λίστα φίλων"
+    pictures_title: "Εικόνες"
+    videos_title: "Βίντεο"
   promote_following:
-    button: Ενεργοποίηση Παρακολούθησης
+    button: "Ενεργοποίηση Παρακολούθησης"
     ps: P.S. Μπορείτε να κλείσετε την Παρακολούθηση όποτε θέλετε.
-    skip: Μην ενεργοποιήσετε την παρακολούθηση για μένα
-    subtitle: Ξεχωρίστε τους φίλους σας απο τους ακόλουθούς σας.
-    title: Παρουσιάζουμαι Ακολουθώ
+    skip: "Μην ενεργοποιήσετε την παρακολούθηση για μένα"
+    subtitle: "Ξεχωρίστε τους φίλους σας απο τους ακόλουθούς σας."
+    title: "Παρουσιάζουμαι Ακολουθώ"
   recommendations:
-    title: Προτάσεις
+    title: "Προτάσεις"
   reset_password:
-    cta: Επαναφέρετε τον κωδικό πρόσβασης
-    error_confirmation_match: Ο κωδικός επιβεβαίωσης δεν ταιριάζει με τον κωδικό πρόσβασης
-    error_password_range: Ο κωδικός πρόσβασης πρέπει να είναι μεταξύ 4 και 100 χαρακτήρων.
+    cta: "Επαναφέρετε τον κωδικό πρόσβασης"
+    error_confirmation_match: "Ο κωδικός επιβεβαίωσης δεν ταιριάζει με τον κωδικό πρόσβασης"
+    error_password_range: "Ο κωδικός πρόσβασης πρέπει να είναι μεταξύ 4 και 100 χαρακτήρων."
     error_token_expired: O χρόνος επαναφοράς του κωδικού πρόσβασης έχει λήξει, παρακαλούμε ζητήσετε ένα νέο
     error_token_invalid: O κωδικός επαναφοράς είναι άκυρος
     footnote: "<b>Pro Tip:</b> Θυμηθείτε τον κωδικό πρόσβασής σας."
-    label_enter: Νέος κωδικός πρόσβασης
-    label_re_enter: Εισάγετε ξανά τον νέο κωδικό πρόσβασης
-    status_flash_success: Ο κωδικός προσβασής έχει αλλάξει με επιτυχία.
-    subtitle: Όχι πολύ μικρός, ούτε πολύ μεγάλος, ακριβώς όπως πρέπει…
-    title: Επαναφέρετε τον κωδικό πρόσβασης
+    label_enter: "Νέος κωδικός πρόσβασης"
+    label_re_enter: "Εισάγετε ξανά τον νέο κωδικό πρόσβασης"
+    status_flash_success: "Ο κωδικός προσβασής έχει αλλάξει με επιτυχία."
+    subtitle: "Όχι πολύ μικρός, ούτε πολύ μεγάλος, ακριβώς όπως πρέπει…"
+    title: "Επαναφέρετε τον κωδικό πρόσβασης"
   select_language:
-    button: Αλλαγή Προεπιλεγμένης Γλώσσας
+    button: "Αλλαγή Προεπιλεγμένης Γλώσσας"
     help_translate: Eπισκεφτείτε το <a class="silver" href="https://github.com/fetlife/translations">μεταφραστικό έργο</a> μας στο GitHub και βοηθήστε να γίνει το FetLife προσβάσιμo σε περισσότερους από τους kinky φίλους μας <span class="amp">&amp</span> κοινότητες.
-    language_name: Ελληνικά
+    language_name: "Ελληνικά"
     sub_header: Hi, hallo, olá, bonjour, ciao, ahoj, opa, szia!
-    title: Επιλέξτε Γλώσσα
+    title: "Επιλέξτε Γλώσσα"
   settings_account:
-    2fa_cta: Ενεργοποιήστε 2-Factor Πιστοποίηση
+    2fa_cta: "Ενεργοποιήστε 2-Factor Πιστοποίηση"
     2fa_label: 2-Factor Πιστοποίηση
     anti_pro_tip: <strong>Anti-Pro Tip:</strong> Μπορείτε να κάνετε <a href="#">Απενεργοποίηση</a> ή <a href="#">Διαγραφή</a> του λογαριασμού σας αν θέλετε, αλλά τρεις στους τέσσερες Πάπες διαφωνούν.
-    current_password_label: Τρέχων Κωδικός Πρόσβασης
-    email_cta: Ενημέρωση της διεύθυνσης email
+    current_password_label: "Τρέχων Κωδικός Πρόσβασης"
+    email_cta: "Ενημέρωση της διεύθυνσης email"
     email_label: Email
-    email_placeholder: Διεύθυνση Email
-    language_cta: Εκσυγχρόνισε Προεπιλεγμένη Γλώσσα
-    language_notice: Το FetLife δεν είναι πλήρως διαθέσιμο σε γλώσσες εκτός της Αγγλικής. Αν αλλάξετε τη ρύθμιση εδώ, δεν θα μεταφραστεί ολόκληρη η ιστοσελίδα.
-    new_password_label: Νέος κωδικός πρόσβασης
-    nickname_cta: Αλλάξτε ψευδώνυμο
+    email_placeholder: "Διεύθυνση Email"
+    language_cta: "Εκσυγχρόνισε Προεπιλεγμένη Γλώσσα"
+    language_notice: "Το FetLife δεν είναι πλήρως διαθέσιμο σε γλώσσες εκτός της Αγγλικής. Αν αλλάξετε τη ρύθμιση εδώ, δεν θα μεταφραστεί ολόκληρη η ιστοσελίδα."
+    new_password_label: "Νέος κωδικός πρόσβασης"
+    nickname_cta: "Αλλάξτε ψευδώνυμο"
     nickname_label: 'Αλλάξτε το ψευδώνυμό σας απο "JohnBaku" σε:'
     nickname_notice: "<strong>Pro Tip:</strong> Μετρήστε δύο φορές, κόψτε μια φορά. Μπορείτε να αλλάξετε το ψευδώνυμό σας μια φορά κάθε 28 ημέρες."
-    nickname_placeholder: Νέο Ψευδώνυμό
-    page_title: Αλλάξτε τον κωδικό πρόσβασης - Ρυθμίσεις
-    password_cta: Επαναφέρετε τον κωδικό πρόσβασης
-    repeat_password_label: Επαναλάβετε τον κωδικό πρόσβασης
-    subtitle: Μην πατήσετε το μεγάλο κόκκινο κουμπί.
-    title: Ρυθμίσεις Λογαριασμού
+    nickname_placeholder: "Νέο Ψευδώνυμό"
+    page_title: "Αλλάξτε τον κωδικό πρόσβασης - Ρυθμίσεις"
+    password_cta: "Επαναφέρετε τον κωδικό πρόσβασης"
+    repeat_password_label: "Επαναλάβετε τον κωδικό πρόσβασης"
+    subtitle: "Μην πατήσετε το μεγάλο κόκκινο κουμπί."
+    title: "Ρυθμίσεις Λογαριασμού"
   settings_notifications:
-    cta: Ενημέρωση Προεπιλεγμένης Γλώσσας
-    language_label: Γλώσσα
-    notice: Το FetLife δεν είναι πλήρως διαθέσιμο σε γλώσσες εκτός της Αγγλικής. Αν αλλάξετε τη ρύθμιση εδώ, δεν θα μεταφραστεί ολόκληρη η ιστοσελίδα.
-    page_title: Γλώσσα - Ρυθμίσεις
-    subtitle: Ποιά γλώσσα προτιμάτε;
-    title: Γλώσσα
+    cta: "Ενημέρωση Προεπιλεγμένης Γλώσσας"
+    language_label: "Γλώσσα"
+    notice: "Το FetLife δεν είναι πλήρως διαθέσιμο σε γλώσσες εκτός της Αγγλικής. Αν αλλάξετε τη ρύθμιση εδώ, δεν θα μεταφραστεί ολόκληρη η ιστοσελίδα."
+    page_title: "Γλώσσα - Ρυθμίσεις"
+    subtitle: "Ποιά γλώσσα προτιμάτε;"
+    title: "Γλώσσα"
   settings_privacy:
-    blocked_list_subtitle: Για αυτούς στη λίστα των άτακτων.
-    blocked_list_title: Λίστα Αποκλεισμού
-    cb_feed: Επιτρέψτε στους μη-φίλους να σας ακολουθούν στη Ροή Δραστηριότητάς τους.
-    cb_fp: Επιτρέψτε τους μη-φίλους posts να εμφανιστούν στο Fresh&Pervy.
-    cb_kp: Επιτρεψτε τους μη-φίλους posts να εμφανιστούν στο Kinky&Popular.
-    content_privacy: Ιδιωτικότητα Περιεχομένου
-    cta: Αποθήκευση Ρυθμίσεων Ιδιωτικότητας
-    following: Παρακολούθηση
-    page_title: Ρυθμίσεις Ιδιωτικότητας
-    subtitle: Σερβίρεται όπως σας αρέσει.
-    title: Ιδιωτικότητα
+    blocked_list_subtitle: "Για αυτούς στη λίστα των άτακτων."
+    blocked_list_title: "Λίστα Αποκλεισμού"
+    cb_feed: "Επιτρέψτε στους μη-φίλους να σας ακολουθούν στη Ροή Δραστηριότητάς τους."
+    cb_fp: "Επιτρέψτε τους μη-φίλους posts να εμφανιστούν στο Fresh&Pervy."
+    cb_kp: "Επιτρεψτε τους μη-φίλους posts να εμφανιστούν στο Kinky&Popular."
+    content_privacy: "Ιδιωτικότητα Περιεχομένου"
+    cta: "Αποθήκευση Ρυθμίσεων Ιδιωτικότητας"
+    following: "Παρακολούθηση"
+    page_title: "Ρυθμίσεις Ιδιωτικότητας"
+    subtitle: "Σερβίρεται όπως σας αρέσει."
+    title: "Ιδιωτικότητα"
     warning: "<strong>Εξαιρετικά Σημαντικό</strong>: Απενεργοποιώντας την παρακολούθηση θα διαγράψετε όλους σας ακολουθούν αυτή τη στιγμή. Σοβαρά."
   settings_profile:
-    about_you_label: Σχετικά με σένα
+    about_you_label: "Σχετικά με σένα"
     add_website: "+ προσθέστε ένα άλλο website"
     cta: Update Το προφίλ σας
-    dob_label: Ημερομηνία Γέννησης
-    location_label: Τοποθεσία
-    looking_for_label: Ψάχνω για
-    page_title: Ενημέρωση του προφίλ
-    subtitle: Η Προσωπική ανάπτυξη είναι καλό πράγμα.
-    title: Το Προφίλ σας
+    dob_label: "Ημερομηνία Γέννησης"
+    location_label: "Τοποθεσία"
+    looking_for_label: "Ψάχνω για"
+    page_title: "Ενημέρωση του προφίλ"
+    subtitle: "Η Προσωπική ανάπτυξη είναι καλό πράγμα."
+    title: "Το Προφίλ σας"
     websites_label: Websites
     websites_placeholder: https://fetlife.com
   settings_support:
-    cta: Επαναφέρετε τη διεύθυνση email
-    email_label: Επαναφέρετε τη διεύθυνση email
-    email_placeholder: Διεύθυνση Email
-    page_title: Επαναφέρετε τη διεύθυνση email - Ρυθμίσεις
-    subtitle: Μόνο στην περίπτωση που ξεχάσατε τον κωδικό πρόσβασης.
-    title: Επαναφέρετε τη διεύθυνση email
+    cta: "Επαναφέρετε τη διεύθυνση email"
+    email_label: "Επαναφέρετε τη διεύθυνση email"
+    email_placeholder: "Διεύθυνση Email"
+    page_title: "Επαναφέρετε τη διεύθυνση email - Ρυθμίσεις"
+    subtitle: "Μόνο στην περίπτωση που ξεχάσατε τον κωδικό πρόσβασης."
+    title: "Επαναφέρετε τη διεύθυνση email"
   sidebar:
-    about_fetlife: Σχετικά με το Fetlife
-    ad_stats: Στατιστικά Διαφημίσεων
-    advertising: Διαφήμιση
+    about_fetlife: "Σχετικά με το Fetlife"
+    ad_stats: "Στατιστικά Διαφημίσεων"
+    advertising: "Διαφήμιση"
     androidapp: Install FetLife's Android App
-    bug_bounty: Αμοιβές για Bugs
+    bug_bounty: "Αμοιβές για Bugs"
     caretaking: Caretaking
-    change_language: Αλλαγή Γλώσσας
-    close: Κλείσιμο
-    edit_profile: Επεξεργασία Προφίλ
-    edit_settings: Επεξεργασία Ρυθμίσεων
-    events: Εκδηλώσεις
-    fetishes: Φετίχ
-    following: Παρακολούθηση
+    change_language: "Αλλαγή Γλώσσας"
+    close: "Κλείσιμο"
+    edit_profile: "Επεξεργασία Προφίλ"
+    edit_settings: "Επεξεργασία Ρυθμίσεων"
+    events: "Εκδηλώσεις"
+    fetishes: "Φετίχ"
+    following: "Παρακολούθηση"
     fp: Fresh & Pervy
-    funny_quote: Αν δεν μπορείτε να διαβάσετε αυτό ... χρειαζόσαστε γυαλιά! - Ιωάννης 4:69
-    gift_support: Κάντε δώρο FetLife Support
+    funny_quote: "Αν δεν μπορείτε να διαβάσετε αυτό ... χρειαζόσαστε γυαλιά! - Ιωάννης 4:69"
+    gift_support: "Κάντε δώρο FetLife Support"
     glossary: Glossary
-    groups: Ομάδες
-    guidelines: Κατευθυντήριες γραμμές
-    home: Αρχική
-    invite_a_friend: Προσκαλέστε ένα Φίλο (%{count})
-    kp: Διαστροφικά & Δημοφιλή
-    legalese: Νομικά
-    log_out: Αποσύνδεση
+    groups: "Ομάδες"
+    guidelines: "Κατευθυντήριες γραμμές"
+    home: "Αρχική"
+    invite_a_friend: "Προσκαλέστε ένα Φίλο (%{count})"
+    kp: "Διαστροφικά & Δημοφιλή"
+    legalese: "Νομικά"
+    log_out: "Αποσύνδεση"
     login: Login
-    loved_stuff: Πράγματα Που Αγαπάτε
-    need_help: Χρειάζεστε βοήθεια?
+    loved_stuff: "Πράγματα Που Αγαπάτε"
+    need_help: "Χρειάζεστε βοήθεια?"
     open_source: Open Source
-    places: Μέρη
+    places: "Μέρη"
     preservation_requests: Preservation Requests
     privacy: Privacy
-    recommendations: Προτάσεις
+    recommendations: "Προτάσεις"
     signup: Signup
     subscriptions: Subscriptions
-    support: Υποστηρίξτε το Fetlife
+    support: "Υποστηρίξτε το Fetlife"
     terms: Terms
-    upload_picture: Μεταφόρτωση Εικόνων
-    upload_video: Μεταφόρτωση Βίντεο
-    view_friends: Προβολή Φίλων
-    whats_new: Τι νέο υπάρχει
-    write_post: Δημιουργία Post
+    upload_picture: "Μεταφόρτωση Εικόνων"
+    upload_video: "Μεταφόρτωση Βίντεο"
+    view_friends: "Προβολή Φίλων"
+    whats_new: "Τι νέο υπάρχει"
+    write_post: "Δημιουργία Post"
   signup:
-    almost_there: Σχεδόν τελειώσατε!
-    error_bar: Χιούστον, έχουμε πρόβλημα. Μετακινηθείτε προς τα κάτω για παραπάνω πληροφορίες.
-    error_birthdate: Απαιτείται ημερομηνία γέννησης.
+    almost_there: "Σχεδόν τελειώσατε!"
+    error_bar: "Χιούστον, έχουμε πρόβλημα. Μετακινηθείτε προς τα κάτω για παραπάνω πληροφορίες."
+    error_birthdate: "Απαιτείται ημερομηνία γέννησης."
     error_birthdate_too_old: Eίστε πολύ μεγάλος.
-    error_birthdate_too_young: Δεν είστε αρκετά μεγάλος (πρέπει να είστε τουλάχιστον 18 χρονών).
-    error_city_missing: Πρέπει να επιλέξετε πόλη.
-    error_country_missing: Πρέπει να επιλέξετε χώρα.
-    error_email: Αντιμετωπίσαμε πρόβλημα με την επεξεργασία αυτού του email. Συνιστούμε να κοιτάξετε την ορθογραφία ή να δοκιμάσετε κάποιο άλλο.
+    error_birthdate_too_young: "Δεν είστε αρκετά μεγάλος (πρέπει να είστε τουλάχιστον 18 χρονών)."
+    error_city_missing: "Πρέπει να επιλέξετε πόλη."
+    error_country_missing: "Πρέπει να επιλέξετε χώρα."
+    error_email: "Αντιμετωπίσαμε πρόβλημα με την επεξεργασία αυτού του email. Συνιστούμε να κοιτάξετε την ορθογραφία ή να δοκιμάσετε κάποιο άλλο."
     error_email_taken: Email has already been taken.
-    error_gender_required: Πρέπει να επιλέξετε τo γένος.
-    error_nickname: Το ψευδώνυμο χρησιμοποιείται ήδη.
+    error_gender_required: "Πρέπει να επιλέξετε τo γένος."
+    error_nickname: "Το ψευδώνυμο χρησιμοποιείται ήδη."
     error_nickname_bad_word: Nickname can't have the word '%{word}' in it.
     error_nickname_characters: Nickname can only contain letters, numbers, dashes and underscores; no spaces.
     error_nickname_length: Nickname has to be between 2 and 16 characters long.
-    error_nickname_required: Απαιτείται ψευδώνυμο.
-    error_password_range: Ο κωδικός πρόσβασης πρέπει να είναι μεταξύ 4 και 100 χαρακτήρων.
-    error_password_required: Απαιτείται κωδικός πρόσβασης.
-    error_role_required: Πρέπει να επιλέξετε το Ρόλο.
-    error_sexual_orientation_required: Πρέπει να επιλέξετε Σεξουαλικό Προσανατολισμό.
-    error_state_missing: Πρέπει να επιλέξετε Κράτος/Επαρχία.
+    error_nickname_required: "Απαιτείται ψευδώνυμο."
+    error_password_range: "Ο κωδικός πρόσβασης πρέπει να είναι μεταξύ 4 και 100 χαρακτήρων."
+    error_password_required: "Απαιτείται κωδικός πρόσβασης."
+    error_role_required: "Πρέπει να επιλέξετε το Ρόλο."
+    error_sexual_orientation_required: "Πρέπει να επιλέξετε Σεξουαλικό Προσανατολισμό."
+    error_state_missing: "Πρέπει να επιλέξετε Κράτος/Επαρχία."
     footnote: Κάνοντας κλικ στο κουμπί συμφωνείτε να σέβεστε και να ακολουθείτε τους <a class="silver" href="%{guidelines_path}">"Κανόνες Κοινότητας"</a> και τους <a class="silver" href="%{tou_path}">Όρους Χρήσης</a>…
-    return_to_login: Already a member? Login to FetLife
     label:
-      birthdate: Ημερομηνία Γέννησης
-      city: Πόλη
-      country: Χώρα
-      email: Διεύθυνση email
-      gender: Γένος
-      location: Τοποθεσία
-      nickname: Ψευδώνυμο
-      password: Κωδικός
-      role: Ρόλος
-      sexual_orientation: Σεξουαλικός Προσανατολισμός
-      state: Κράτος/Επαρχία
-    page_title: συμμετοχή
-    subtitle: Πείτε μας για τον εαυτό σας.
+      birthdate: "Ημερομηνία Γέννησης"
+      city: "Πόλη"
+      country: "Χώρα"
+      email: "Διεύθυνση email"
+      gender: "Γένος"
+      location: "Τοποθεσία"
+      nickname: "Ψευδώνυμο"
+      password: "Κωδικός"
+      role: "Ρόλος"
+      sexual_orientation: "Σεξουαλικός Προσανατολισμός"
+      state: "Κράτος/Επαρχία"
+    page_title: "συμμετοχή"
+    return_to_login: Already a member? Login to FetLife
+    subtitle: "Πείτε μας για τον εαυτό σας."
     subtitle_invite: "%{name} σας προσκάλεσε να συμμετάσχετε στο FetLife."
-    title: Καλοσώρισες σπίτι
+    title: "Καλοσώρισες σπίτι"
   signup_avatar:
     pro_tip: '<strong>Pro Tip</strong>: Αν είστε ντροπαλοί και δεν θέλετε να δείξετε το προσωπό σας, μη διστάσετε να είστε δημιουργικοί και δείξτε μια άλλη πλευρά του εαυτού σας! Ή, αν προτιμάτε, μπορείτε να <a class="silver" href="%{next_step_path}">παραλείψετε αυτό το βήμα</a> για τώρα.'
-    say_cheese: Χαμογελάστε!
-    subtitle: Χρήστες με avatars περνάνε 69x καλύτερα!
-    title: Ανεβάστε ένα avatar
+    say_cheese: "Χαμογελάστε!"
+    subtitle: "Χρήστες με avatars περνάνε 69x καλύτερα!"
+    title: "Ανεβάστε ένα avatar"
   signup_five_strikes:
     page_title: Five Strike Rule
-    return_to_front: Επιστρέψετε στην αρχική σελίδα
-    subtitle_error: Για λόγους ασφάλειας, θα πρέπει να περιμένετε δύο ώρες πριν να μπορέσετε να εγγραφείτε ξανά.
+    return_to_front: "Επιστρέψετε στην αρχική σελίδα"
+    subtitle_error: "Για λόγους ασφάλειας, θα πρέπει να περιμένετε δύο ώρες πριν να μπορέσετε να εγγραφείτε ξανά."
     title: Five Strike Rule
   signup_follow:
-    follow: Ακολουθήστε
-    next_step: Επόμενο βήμα
-    subtitle: Ακολουθήστε kinksters που σας κίνησαν το ενδιαφέρον.
-    title: Σας τράβηξε κάποιος την προσοχή;
+    follow: "Ακολουθήστε"
+    next_step: "Επόμενο βήμα"
+    subtitle: "Ακολουθήστε kinksters που σας κίνησαν το ενδιαφέρον."
+    title: "Σας τράβηξε κάποιος την προσοχή;"
   signup_phone:
-    cta: Στείλτε μου τον κωδικό επιβεβαίωσης
+    cta: "Στείλτε μου τον κωδικό επιβεβαίωσης"
     error_blocked: "<strong>Kinky Operator:</strong> Unfortunately, we currently don't allow people to signup using a %{carrier_name} number."
     error_cant_send: "<strong>Διεστραμμένος Χειριστής:</strong> Αντιμετωπίσαμε πρόβλημα με την αποστολή μηνύματος κειμένου.  και ότι δεν προσπαθείτε να στείλετε μήνυμα από σταθερό."
     error_quota: "<strong>Διεστραμμένος Χειριστής:</strong> Δεν μπορούμε να στείλουμε περισσότερα από 3 μηνύματα κειμένου στον ίδιο αριθμό σε ένα 24ωρο. Παρακαλώ προσπαθήστε ξανά αργότερα."
-    explanation: Ξέρουμε ότι είναι πολλά αυτά που ζητάμε, αλλά για να διατηρήσουμε μια υγιή και ζωντανή κοινότητα, πρέπει να επιβεβαιώσουμε τον κάθε άνθρωπο πριν γίνει μέλος. Κάτι που πιστεύουμε ότι θα εκτιμήσετε πάρα πολύ.
-    label: Αριθμός Κινητού Τηλεφώνου
-    page_title: Στείλτε τον κωδικό επιβεβαίωσης
+    explanation: "Ξέρουμε ότι είναι πολλά αυτά που ζητάμε, αλλά για να διατηρήσουμε μια υγιή και ζωντανή κοινότητα, πρέπει να επιβεβαιώσουμε τον κάθε άνθρωπο πριν γίνει μέλος. Κάτι που πιστεύουμε ότι θα εκτιμήσετε πάρα πολύ."
+    label: "Αριθμός Κινητού Τηλεφώνου"
+    page_title: "Στείλτε τον κωδικό επιβεβαίωσης"
     pro_tip: "<strong>Pro Tip:</strong> Βεβαιωθείτε ότι αρχίσατε την εισαγωγή του αριθμού σας με τον κωδικό της χώρας σας: +1 για την Αμερική και τον Καναδά, +44 για το Ηνωμένο Βασίλειο, +61 για την Αυστραλία, +31 για την Ολλανδία, +49 για την Γερμανία, +33 για την Γαλλία, κτλ."
-    subtitle: Ανώνυμο μήνυμα κειμένου μίας φοράς.
-    title: Ώρα για πιστοποιήση!
+    subtitle: "Ανώνυμο μήνυμα κειμένου μίας φοράς."
+    title: "Ώρα για πιστοποιήση!"
   signup_verify:
-    cta: Συμπληρώστε την Εγγραφή & Πιστοποίηση
+    cta: "Συμπληρώστε την Εγγραφή & Πιστοποίηση"
     incorrect_code: "<strong>Διεστραμμένος Χειριστής:</strong> Ωχ... ο κωδικός πιστοποίησης φαίνεται λάθος. Παρακαλώ βεβαιωθείτε ότι ο αριθμός ταιριάζει με αυτόν που σας στείλαμε και προσπαθήστε ξανά."
-    label: Κωδικός πιστοποίησης
+    label: "Κωδικός πιστοποίησης"
     notice: Στείλαμε τον κωδικό πιστοποίησης στο <strong>%{phone_number}</strong>. Αν μετά από δύο λεπτά δεν έχετε λάβει μήνυμα κειμένου από εμάς, <a class="silver" href="%{back_path}">ενημερώστε τον αριθμό σας και θα σας στείλουμε νέο κωδικό πιστοποίησης</a>.
-    page_title: Εισάγετε τον κωδικό πιστοποίησης
-    placeholder: Εξαψήφιος κωδικός πιστοποίησης
-    subtitle: Αυτό δεν πόνεσε και πολύ?!?!
-    title: Τελευταίο βήμα
+    page_title: "Εισάγετε τον κωδικό πιστοποίησης"
+    placeholder: "Εξαψήφιος κωδικός πιστοποίησης"
+    subtitle: "Αυτό δεν πόνεσε και πολύ?!?!"
+    title: "Τελευταίο βήμα"
   subnav:
     feed:
-      activity_feed: Ροή Δραστηριότητας
-      activity_feed_short: Αρχική
+      activity_feed: "Ροή Δραστηριότητας"
+      activity_feed_short: "Αρχική"
       fp: Φρέσκο<span class="a-ampersand">&</span>Διεστραμμένο
-      fp_short: Φρέσκο
+      fp_short: "Φρέσκο"
       kp: Διαστροφικά<span class="a-ampersand">&</span>Δημοφιλή
-      kp_short: δημοφιλής
+      kp_short: "δημοφιλής"
     profile:
-      about: Σχετικά με εμένα
-      about_short: Σχετικά
-      latest: Τελευταία δραστηριότητα
-      latest_short: Τελευταία
-      pictures: Εικόνες
+      about: "Σχετικά με εμένα"
+      about_short: "Σχετικά"
+      latest: "Τελευταία δραστηριότητα"
+      latest_short: "Τελευταία"
+      pictures: "Εικόνες"
       pictures_short: Pics
-      videos: βίντεο
-      videos_short: βιντ
-      writings: Γραπτά
-      writings_short: Γραπτά
+      videos: "βίντεο"
+      videos_short: "βιντ"
+      writings: "Γραπτά"
+      writings_short: "Γραπτά"
     settings:
-      account: Λογαριασμός
-      account_short: Λογαριασμός
-      notifications: Ειδοποιήσεις
-      notifications_short: Ειδοποιήσεις
-      privacy: Ιδιωτικότητα
-      privacy_short: Ιδιωτικότητα
-      profile: Προφίλ
-      profile_short: Προφίλ
-      support: Υποστήριξη
-      support_short: Υποστήριξη
+      account: "Λογαριασμός"
+      account_short: "Λογαριασμός"
+      notifications: "Ειδοποιήσεις"
+      notifications_short: "Ειδοποιήσεις"
+      privacy: "Ιδιωτικότητα"
+      privacy_short: "Ιδιωτικότητα"
+      profile: "Προφίλ"
+      profile_short: "Προφίλ"
+      support: "Υποστήριξη"
+      support_short: "Υποστήριξη"
   support:
     benefits:
       item_1: A sexy <span>I Support FetLife</span> badge on your profile.

--- a/locales/gr.yml
+++ b/locales/gr.yml
@@ -190,7 +190,7 @@ gr:
   reset_password:
     cta: "Επαναφέρετε τον κωδικό πρόσβασης"
     error_confirmation_match: "Ο κωδικός επιβεβαίωσης δεν ταιριάζει με τον κωδικό πρόσβασης"
-    error_password_range: "Ο κωδικός πρόσβασης πρέπει να είναι μεταξύ 4 και 100 χαρακτήρων."
+    error_password_range: "Ο κωδικός πρόσβασης πρέπει να είναι μεταξύ 8 και 100 χαρακτήρων."
     error_token_expired: O χρόνος επαναφοράς του κωδικού πρόσβασης έχει λήξει, παρακαλούμε ζητήσετε ένα νέο
     error_token_invalid: O κωδικός επαναφοράς είναι άκυρος
     footnote: "<b>Pro Tip:</b> Θυμηθείτε τον κωδικό πρόσβασής σας."
@@ -322,7 +322,7 @@ gr:
     error_nickname_characters: Nickname can only contain letters, numbers, dashes and underscores; no spaces.
     error_nickname_length: Nickname has to be between 2 and 16 characters long.
     error_nickname_required: "Απαιτείται ψευδώνυμο."
-    error_password_range: "Ο κωδικός πρόσβασης πρέπει να είναι μεταξύ 4 και 100 χαρακτήρων."
+    error_password_range: "Ο κωδικός πρόσβασης πρέπει να είναι μεταξύ 8 και 100 χαρακτήρων."
     error_password_required: "Απαιτείται κωδικός πρόσβασης."
     error_role_required: "Πρέπει να επιλέξετε το Ρόλο."
     error_sexual_orientation_required: "Πρέπει να επιλέξετε Σεξουαλικό Προσανατολισμό."

--- a/locales/hu.yml
+++ b/locales/hu.yml
@@ -190,7 +190,7 @@ hu:
   reset_password:
     cta: Jelszó visszaállítása
     error_confirmation_match: A megerősítő jelszó nem egyezik az eredetivel
-    error_password_range: A te jelszavad pedig légyen legalább 4 de nem több mint 100 karakter
+    error_password_range: A te jelszavad pedig légyen legalább 8 de nem több mint 100 karakter
     error_token_expired: A jelszó helyreállító kód érvényessége lejárt, igényelj újat!
     error_token_invalid: A jelszó helyreállító kód nem érvényes
     footnote: "<b>A profi tanácsa:</b> Vésd az eszedbe a jelszavad."
@@ -322,7 +322,7 @@ hu:
     error_nickname_characters: Nickname can only contain letters, numbers, dashes and underscores; no spaces.
     error_nickname_length: Nickname has to be between 2 and 16 characters long.
     error_nickname_required: Felhasználó név nélkül nehézkes ;)
-    error_password_range: A te jelszavad pedig légyen legalább 4 de nem több mint 100 karakter.
+    error_password_range: A te jelszavad pedig légyen legalább 8 de nem több mint 100 karakter.
     error_password_required: Biztonsági szó nélkül nem lenne olyan biztonságos, ugye megérted?
     error_role_required: Fontos hogy milyen preferenciáid vannak egy szerepjátékban. Már csak a félreértés elkerülése végett is.
     error_sexual_orientation_required: A Szexuális beállítottság nem egy elhanyagolható tényező.

--- a/locales/hu.yml
+++ b/locales/hu.yml
@@ -16,7 +16,7 @@ hu:
     email_us: 'Küldj nekünk egy emailt a <a href="mailto:support@fetlife.com">support@fetlife.com</a> címre és mi válaszolunk, mielőtt annyit mondanál: "Fapapucs"! Najó, ilyen hamar azért nem ;)'
     europe: Európa
     got_question: Kérdésed van? Segíthetünk?
-    north_america: Észak-Amerika
+    north_america: "Észak-Amerika"
     one_love: Egy élet, egy szerelem és rengeteg élvezet.
     snail_mail: Csigalevél
     sub_header: Nem összekeverendő a Spártaiakkal
@@ -194,8 +194,8 @@ hu:
     error_token_expired: A jelszó helyreállító kód érvényessége lejárt, igényelj újat!
     error_token_invalid: A jelszó helyreállító kód nem érvényes
     footnote: "<b>A profi tanácsa:</b> Vésd az eszedbe a jelszavad."
-    label_enter: Új jelszó
-    label_re_enter: Új jelszó még egyszer
+    label_enter: "Új jelszó"
+    label_re_enter: "Új jelszó még egyszer"
     status_flash_success: A jelszavad sikeresen megváltozott.
     subtitle: Nem túl hosszú, nem túl rövid, csak pont... de hisz tudod ;)
     title: Jelszó helyreállítása
@@ -213,16 +213,16 @@ hu:
     email_cta: Update Email cím
     email_label: Email
     email_placeholder: Email cím
-    language_cta: Új alapértelmezett nyelv
+    language_cta: "Új alapértelmezett nyelv"
     language_notice: A FetLife fordítása még nem teljese. Ha megváltoztatod ezt a beállítást, az oldal bizonyos részei továbbra is angolul fognak megjelenni.
-    new_password_label: Új jelszó
+    new_password_label: "Új jelszó"
     nickname_cta: Felhasználónév
     nickname_label: " A felhasználónév megváltoztatása:"
     nickname_notice: "<strong>A profi tanácsa:</strong> Mérd kétszer, Vágd egyszer. A felhasználó nevedet csak 28 naponta változtathatod meg. Nincs kivétel."
-    nickname_placeholder: Új felahasználónév
+    nickname_placeholder: "Új felahasználónév"
     page_title: Jelszó megváltoztatása - Beállítások
-    password_cta: Új jelszó
-    repeat_password_label: Új jelszó még egyszer
+    password_cta: "Új jelszó"
+    repeat_password_label: "Új jelszó még egyszer"
     subtitle: Kérjük nyomja meg a piros gombot és nyugodjon békében.
     title: Felhasználói beállítások
   settings_notifications:
@@ -270,7 +270,7 @@ hu:
     advertising: Hirdetés
     androidapp: Install FetLife's Android App
     bug_bounty: Hiba vadászat
-    caretaking: Ügyfélszolgálat
+    caretaking: "Ügyfélszolgálat"
     change_language: Nyelv kiválasztása
     close: bezárás
     edit_profile: Profil szerkesztése
@@ -304,7 +304,7 @@ hu:
     upload_picture: Kép feltöltése
     upload_video: Videó feltöltése
     view_friends: Ismerősök
-    whats_new: Újdonságok
+    whats_new: "Újdonságok"
     write_post: Bejegyzés közzététele
   signup:
     almost_there: Szinte kész!
@@ -328,7 +328,6 @@ hu:
     error_sexual_orientation_required: A Szexuális beállítottság nem egy elhanyagolható tényező.
     error_state_missing: A megye kiválasztása kötelező.
     footnote: A továbblépéssel elfogadod, hogy követed a <a class="silver" href="%{guidelines_path}">közösségi szabályzatot</a> és elfogadod a <a class="silver" href="%{tou_path}">felhasználási feltételeket</a>. Még most olvasd el, különben úgy vesszük, hogy megtetted.
-    return_to_login: Already a member? Login to FetLife
     label:
       birthdate: Születési idő
       city: Város
@@ -342,6 +341,7 @@ hu:
       sexual_orientation: Szexuális beállítottság
       state: Megye
     page_title: Csatlakozás
+    return_to_login: Already a member? Login to FetLife
     subtitle: Mesélj egy kicsit magadról!
     subtitle_invite: "%{name} meghívott, hogy csatlakozz a FetLife közösséghez."
     title: Isten hozott itthon
@@ -397,13 +397,13 @@ hu:
       pictures_short: Képek
       videos: Videók
       videos_short: Videók
-      writings: Írások
-      writings_short: Írások
+      writings: "Írások"
+      writings_short: "Írások"
     settings:
       account: Felhasználói fiók
       account_short: Felhasználó
-      notifications: Értesítések
-      notifications_short: Értesítések
+      notifications: "Értesítések"
+      notifications_short: "Értesítések"
       privacy: Adatvédelem
       privacy_short: Adatvédelem
       profile: Profil

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -328,7 +328,6 @@ it:
     error_sexual_orientation_required: L'orientamento sessuale deve essere selezionato.
     error_state_missing: Lo stato/provincia deve essere selezionato.
     footnote: Cliccando sul pulsante sopra l'utente accetta di rispettare e seguire le nostre <a class="silver" href="%{guidelines_path}">Linee guida della Community</a> e le <a class="silver" href="%{tou_path}">Condizioni d'uso</a>&hellip; niente restituzioni.
-    return_to_login: Already a member? Login to FetLife
     label:
       birthdate: Data di nascita
       city: Città
@@ -342,6 +341,7 @@ it:
       sexual_orientation: Orientamento Sessuale
       state: Stato/provincia
     page_title: Unisciti
+    return_to_login: Already a member? Login to FetLife
     subtitle: Parlaci un po' di te.
     subtitle_invite: "%{name} ti ha invitat* ad iscriverti a FetLife."
     title: Benvenuto a casa

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -190,7 +190,7 @@ it:
   reset_password:
     cta: Reimposta la mia password
     error_confirmation_match: I due campi password non coincidono
-    error_password_range: La password deve essere tra 4 e 100 caratteri
+    error_password_range: La password deve essere tra 8 e 100 caratteri
     error_token_expired: Il token per reimpostare la password è scaduto, si prega di richiederne uno nuovo
     error_token_invalid: Il token per reimpostare la password non è valido
     footnote: "<b>Consiglio Pro:</b> Ricordati la tua password."
@@ -322,7 +322,7 @@ it:
     error_nickname_characters: Nickname can only contain letters, numbers, dashes and underscores; no spaces.
     error_nickname_length: Nickname has to be between 2 and 16 characters long.
     error_nickname_required: Il nickname è richiesto.
-    error_password_range: La password deve essere tra 4 e 100 caratteri.
+    error_password_range: La password deve essere tra 8 e 100 caratteri.
     error_password_required: La password è richiesta.
     error_role_required: Il ruolo deve essere selezionato.
     error_sexual_orientation_required: L'orientamento sessuale deve essere selezionato.

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -190,7 +190,7 @@ nl:
   reset_password:
     cta: Herstel mijn wachtwoord
     error_confirmation_match: Wachtwoord bevestiging is niet gelijk aan het wachtwoord
-    error_password_range: Wachtwoord moet uit 4 tot 100 karakters bestaan
+    error_password_range: Wachtwoord moet uit 8 tot 100 karakters bestaan
     error_token_expired: Herstel wachtwoord token is verlopen, vraag een nieuwe aan
     error_token_invalid: Herstel wachtwoord token is niet juist
     footnote: "<b>Pro Tip:</b> Vergeet je wachtwoord niet."
@@ -322,7 +322,7 @@ nl:
     error_nickname_characters: Bijnaam kan enkel leters, nummers, streepjes en lage streepjes bevatten; geen spaties.
     error_nickname_length: Bijnaam moet tussen 2 en 16 karakters lang zijn.
     error_nickname_required: Alias is verplicht.
-    error_password_range: Wachtwoord moet uit 4 tot 100 karakters bestaan.
+    error_password_range: Wachtwoord moet uit 8 tot 100 karakters bestaan.
     error_password_required: Wachtwoord is verplicht.
     error_role_required: Rol moet worden gekozen.
     error_sexual_orientation_required: Sexuele orientatie moet worden gekozen.

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -328,7 +328,6 @@ nl:
     error_sexual_orientation_required: Sexuele orientatie moet worden gekozen.
     error_state_missing: Provincie moet worden geselecteerd.
     footnote: Door het klikken op bovenstaande knop ga je akkoord om onze <a class="silver" href="%{guidelines_path}">gemeenschap richtlijnen</a> en <a class="silver" href="%{tou_path}">Gebruiksvoorwaarden</a> te respecteren en op te volgen&hellip; zonder voorbehoud.
-    return_to_login: Al een lid? Meld je hier aan bij FetLife
     label:
       birthdate: Geboortedatum
       city: Plaats
@@ -342,6 +341,7 @@ nl:
       sexual_orientation: Sexuele Orientatie
       state: Provincie
     page_title: Deelnemen
+    return_to_login: Al een lid? Meld je hier aan bij FetLife
     subtitle: Vertel ons een beetje over jezelf.
     subtitle_invite: "%{name} nodigt jou om lid te worden van FetLife."
     title: Welkom thuis

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -93,7 +93,7 @@ pt:
     tab_email: Email
     tab_mobile: Telemovel
   guidelines:
-    last_updated: 'Última atualização:'
+    last_updated: "Última atualização:"
     subnav:
       community: Comunidade
       content: Conteúdo
@@ -328,7 +328,6 @@ pt:
     error_sexual_orientation_required: Orientação Sexual é obrigatória.
     error_state_missing: Estado é obrigatório.
     footnote: Ao clicar no botão acima você aceita respeitar e seguir nossas <a class="silver" href="%{guidelines_path}">Orientações de Comunidade</a> e <a class="silver" href="%{tou_path}">Termos de uso</a>&hellip; sem voltar atrás.
-    return_to_login: Already a member? Login to FetLife
     label:
       birthdate: Data de Nascimento
       city: Cidade
@@ -342,6 +341,7 @@ pt:
       sexual_orientation: Orientação Sexual
       state: Estado
     page_title: Cadastrar
+    return_to_login: Already a member? Login to FetLife
     subtitle: Conte-nos um pouco sobre você.
     subtitle_invite: "%{name} lhe convidou a participar do FetLife."
     title: Boas Vindas
@@ -379,7 +379,7 @@ pt:
     page_title: Insira o Código de Verificação
     placeholder: Código de Verificação em 6 dígitos
     subtitle: Até que não doeu, pois não?
-    title: Último Passo
+    title: "Último Passo"
   subnav:
     feed:
       activity_feed: Feed de Atividade

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -190,7 +190,7 @@ pt:
   reset_password:
     cta: Redefinir Senha
     error_confirmation_match: A confirmação de senha não confere
-    error_password_range: A senha precisa ter entre 4 e 100 caracteres
+    error_password_range: A senha precisa ter entre 8 e 100 caracteres
     error_token_expired: O token de redefinição de senha expirou. Por favor, solicite outro.
     error_token_invalid: O token de redefinição de senha é inválido.
     footnote: "<b>Dica:</b> Lembre-se de sua senha."
@@ -322,7 +322,7 @@ pt:
     error_nickname_characters: 'Nome de Utilizador só pode conter: letras, numeros, hífenes e sublinhado e sem espaços.'
     error_nickname_length: O Nome de Utilizador tem de ser entre 6 e 16 caracteres.
     error_nickname_required: Nome de Utilizador é obrigatório.
-    error_password_range: A senha precisa ter entre 4 e 100 caracteres.
+    error_password_range: A senha precisa ter entre 8 e 100 caracteres.
     error_password_required: Senha é obrigatória.
     error_role_required: Função é obrigatória.
     error_sexual_orientation_required: Orientação Sexual é obrigatória.

--- a/locales/sk.yml
+++ b/locales/sk.yml
@@ -31,8 +31,8 @@ sk:
       other: "%{count_with_delimiter} komentárov"
     composer:
       button: Zdielať
-      placeholder: Čo máš na mysli?
-    love: Ľúbi sa mi to
+      placeholder: "Čo máš na mysli?"
+    love: "Ľúbi sa mi to"
     loved_hover: Lámač sŕdc! :-(
     loves_count:
       one: 1 členovi sa to ľúbi
@@ -89,7 +89,7 @@ sk:
         subtitle: Práve me ti &ldquo;asi&rdquo; poslali SMS.
         title: Zadaj verfikačný kód
       warning: "<strong>Varovanie ministra vnútra:</strong> Z bezpečnostných dôvodov ti nemôžeme povedať, že či dané mobilné číslo sa nachádza v našej databáze alebo nie. Ak nedostaneš SMS, tak je to pravdepodobne kvôli tomu, že ešte nemáš u nás účet."
-    next_step: ďalší krok
+    next_step: "ďalší krok"
     return_to_login: späť na prihlásenie
     tab_email: Email
     tab_mobile: Mobil
@@ -112,7 +112,7 @@ sk:
       email: Emailová adresa
       friends_email: Priateľov email
       friends_email_sub: "%{count} invitations remaining"
-    next_step: ďalší krok
+    next_step: "ďalší krok"
     return_to_feed: späť na feed
     subtitle_step1:
       few: Ostávajú ti %{count_with_delimiter} pozvánky.
@@ -151,7 +151,7 @@ sk:
       password: Heslo
       remember_me: Pamätaj si ma, budem späť.
     not_a_member: Ešte nie si členom? Registruj sa na FetLife
-    subtitle: Čo by sme bez Teba robili?
+    subtitle: "Čo by sme bez Teba robili?"
     title: Vitaj doma
   logout:
     log_in: znova sa prihlásiť
@@ -309,7 +309,7 @@ sk:
     upload_picture: Nahraj fotku
     upload_video: Nahraj video
     view_friends: Zobraz priateľov
-    whats_new: Čo nové?
+    whats_new: "Čo nové?"
     write_post: Napísať príspevok
   signup:
     almost_there: Už si skoro tam!
@@ -333,7 +333,6 @@ sk:
     error_sexual_orientation_required: Sexuálna orientácia je povinná.
     error_state_missing: Kraj je povinný.
     footnote: Kliknutím na tlačidlo vyššie súhlasíš, že budeš rešpektovať naše <a class="silver" href="%{guidelines_path}">komunitné pravidlá</a> a <a class="silver" href="%{tou_path}">podmienky používania</a>.
-    return_to_login: Already a member? Login to FetLife
     label:
       birthdate: Dátum narodenia
       city: Mesto
@@ -347,13 +346,14 @@ sk:
       sexual_orientation: Sexuálna orientácia
       state: Kraj
     page_title: Pridaj sa k nám
+    return_to_login: Already a member? Login to FetLife
     subtitle: Povedz nám niečo málo o sebe.
     subtitle_invite: Uživateľ %{name} ťa pozval na FetLife.
     title: Vitaj doma
   signup_avatar:
     pro_tip: '<strong>Pro Tip</strong>: Ak sa hanbíš a preferuješ neukázať svoju tvár, tak nám neváhaj ukázať niečo iné! ;) Alebo môžes <a class="silver" href="%{next_step_path}">preskočiť tento krok</a> pre teraz.'
     say_cheese: Povedz "syyyyyr"!
-    subtitle: Ľudia s profilovou fotkou majú 69x viac zábavy!
+    subtitle: "Ľudia s profilovou fotkou majú 69x viac zábavy!"
     title: Nahrať profilovú fotku
   signup_five_strikes:
     page_title: Pravidlo piatich pokusov
@@ -362,7 +362,7 @@ sk:
     title: Pravidlo piatich pokusov
   signup_follow:
     follow: Sledovať
-    next_step: Ďalší krok
+    next_step: "Ďalší krok"
     subtitle: Sleduj kinksterov, ktorí zaujmu tvoje oko.
     title: Zaujal ťa niekto?
   signup_phone:
@@ -375,7 +375,7 @@ sk:
     page_title: Pošli mi verifikačný kód
     pro_tip: "<strong>Pro Tip:</strong> Nezabudni na kód krajiny v mobilnom čísle: +421 pre Slovenko, +420 pre Českú Republiku, atď."
     subtitle: Jednorázová anonymná správa.
-    title: Čas na verifikáciu!
+    title: "Čas na verifikáciu!"
   signup_verify:
     cta: Dokonči registráciu a verifikáciu
     incorrect_code: "<strong>Kinky Operátor:</strong> Oh&hellip; zadaný verifikačný kód nie je spravný. Prosím skontroluj kód a skús znova."
@@ -402,11 +402,11 @@ sk:
       pictures_short: Fotky
       videos: Videá
       videos_short: Videá
-      writings: Články
-      writings_short: Články
+      writings: "Články"
+      writings_short: "Články"
     settings:
-      account: Účet
-      account_short: Účet
+      account: "Účet"
+      account_short: "Účet"
       notifications: Upozornenia
       notifications_short: Upozornenia
       privacy: Súkromie

--- a/locales/sk.yml
+++ b/locales/sk.yml
@@ -195,7 +195,7 @@ sk:
   reset_password:
     cta: Resetovať heslo
     error_confirmation_match: Zadané heslá sa nezhodujú
-    error_password_range: Heslo musí mať 4 až 100 znakov
+    error_password_range: Heslo musí mať 8 až 100 znakov
     error_token_expired: Platnosť tokenu na zresetovanie hesla vypršala, prosíme ťa skús znovu.
     error_token_invalid: Token na zresetovanie hesla nie je platný
     footnote: "<b>Pro Tip:</b> Zapamätaj si svoje heslo."
@@ -327,7 +327,7 @@ sk:
     error_nickname_characters: Nickname can only contain letters, numbers, dashes and underscores; no spaces.
     error_nickname_length: Nickname has to be between 2 and 16 characters long.
     error_nickname_required: Prezývka je povinná.
-    error_password_range: Heslo musí mať 4 až 100 znakov.
+    error_password_range: Heslo musí mať 8 až 100 znakov.
     error_password_required: Heslo je povinné.
     error_role_required: Rola je povinná.
     error_sexual_orientation_required: Sexuálna orientácia je povinná.


### PR DESCRIPTION
I used the irb mode of `i18n-tasks` to do this quickly.  However this requires normalization of the files so we can easily see what was actually changed.

The [normalize commit](https://github.com/fetlife/translations/commit/14b216b9d5f5049054294935f14723894ac107b9) is nothing more than `i18n-tasks normalize`

The diff between the normalization and the changes is: https://github.com/fetlife/translations/compare/14b216b9d5f5049054294935f14723894ac107b9...pass-len-eight

The code I pasted into `i18n-tasks irb`:
```
def change_lang(lang_code='en')
  lang = tree(lang_code)
  %w(signup.error_password_range reset_password.error_password_range).each do |key|
    lang[key].value = lang[key].value.gsub(/ 4 /, " 8 ")
    puts "[#{lang_code}][#{key}] = #{lang[key].value}"
  end
  File.write("locales/#{lang.parent.key}.yml", lang.parent.to_yaml(line_width: -1))
end

def change_all
  Dir.glob("locales/*.yml").each do |file|
    lang_code = File.basename(file, ".yml")
    change_lang lang_code
  end
end
```