### PR TITLE
Add Website url attribute human name

### DIFF
--- a/locales/bg.yml
+++ b/locales/bg.yml
@@ -21,6 +21,10 @@ bg:
     snail_mail: Поща
     sub_header: Не ни бъркай със спартанците.
     title: Ние. Сме. FetLife!
+  activerecord:
+    attributes:
+      website:
+        url: URL
   components:
     step: Step
   edit_profile:

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -21,6 +21,10 @@ de:
     snail_mail: Schneckenpost
     sub_header: Nicht zu verwechseln mit den Spartanern.
     title: Wir! Sind! FetLife!
+  activerecord:
+    attributes:
+      website:
+        url: URL
   components:
     step: Schritt
   edit_profile:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -21,6 +21,10 @@ en:
     snail_mail: Snail Mail
     sub_header: Not to be confused with the Spartans.
     title: We. Are. FetLife!
+  activerecord:
+    attributes:
+      website:
+        url: 'URL'
   components:
     step: Step
   edit_profile:

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -21,6 +21,10 @@ es:
     snail_mail: Correo postal
     sub_header: No se confunda con los espartanos.
     title: Nosotros. Somos. ¡FetLife!
+  activerecord:
+    attributes:
+      website:
+        url: URL
   components:
     step: Step
   edit_profile:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -21,6 +21,10 @@ fr:
     snail_mail: Courrier papier
     sub_header: À ne pas confondre avec les spartiates
     title: Nous. Sommes. FetLife !
+  activerecord:
+    attributes:
+      website:
+        url: URL
   components:
     step: Step
   edit_profile:

--- a/locales/gr.yml
+++ b/locales/gr.yml
@@ -21,6 +21,10 @@ gr:
     snail_mail: Αργό Ταχυδρομείο
     sub_header: Μην το μπερδεύετε με τους Σπαρτιάτες.
     title: Είμαστε το FetLife!
+  activerecord:
+    attributes:
+      website:
+        url: URL
   components:
     step: Step
   edit_profile:

--- a/locales/hu.yml
+++ b/locales/hu.yml
@@ -21,6 +21,10 @@ hu:
     snail_mail: Csigalevél
     sub_header: Nem összekeverendő a Spártaiakkal
     title: 'Mi vagyunk a: FetLife!'
+  activerecord:
+    attributes:
+      website:
+        url: URL
   components:
     step: Step
   edit_profile:

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -21,6 +21,10 @@ it:
     snail_mail: Posta
     sub_header: Da non confondere con gli Spartani.
     title: Noi. Siamo. FetLife!
+  activerecord:
+    attributes:
+      website:
+        url: URL
   components:
     step: Step
   edit_profile:

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -21,6 +21,10 @@ nl:
     snail_mail: Slakken post
     sub_header: Niet te verwarren met de Spartanen.
     title: Wij. Zijn. FetLife!
+  activerecord:
+    attributes:
+      website:
+        url: URL
   components:
     step: Step
   edit_profile:

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -21,6 +21,10 @@ pl:
     snail_mail: Prawdziwa poczta
     sub_header: Nie mylić ze Spartanami.
     title: We. Are. FetLife!
+  activerecord:
+    attributes:
+      website:
+        url: URL
   components:
     step: Krok
   edit_profile:

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -21,6 +21,10 @@ pt:
     snail_mail: Correio
     sub_header: Não confundir com Os Espartanos.
     title: Nós. Somos. FetLife!
+  activerecord:
+    attributes:
+      website:
+        url: URL
   components:
     step: Passo
   edit_profile:

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -21,6 +21,10 @@ ru:
     snail_mail: Обычная Почта
     sub_header: Не путать со спартанцами.
     title: Мы FetLife!
+  activerecord:
+    attributes:
+      website:
+        url: URL
   components:
     step: Шаг
   edit_profile:

--- a/locales/sk.yml
+++ b/locales/sk.yml
@@ -21,6 +21,10 @@ sk:
     snail_mail: Pošta
     sub_header: Nemýliť so Sparťanmi.
     title: My. Sme. FetLife!
+  activerecord:
+    attributes:
+      website:
+        url: URL
   components:
     step: Step
   edit_profile:

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -21,6 +21,10 @@ tr:
     snail_mail: Normal Posta
     sub_header: Spartalılar'la karıştırılmaması gerekir.
     title: Biz. Hepimiz. Fetlife!
+  activerecord:
+    attributes:
+      website:
+        url: URL
   components:
     step: Adım
   edit_profile:

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -21,6 +21,10 @@ zh:
     snail_mail: 老派邮件地址
     sub_header: 不，不是斯巴达
     title: 我们・是・FetLife！
+  activerecord:
+    attributes:
+      website:
+        url: URL
   components:
     step: 步骤
   edit_profile:


### PR DESCRIPTION
This is needed in order to display the `url` attribute name as "URL" instead of "Url" in error messages.