### PR TITLE
Translate recently added error_bar_invalid_credentials to PT and ES

### DIFF
--- a/locales/es.yml
+++ b/locales/es.yml
@@ -374,7 +374,7 @@ es:
   signup:
     almost_there: "¡Casi estamos!"
     error_bar: Dallas, tenemos un problema. Desplácese hacia abajo para obtener más información.
-    error_bar_invalid_credentials: Looks like your Nickname, Email or Password is incorrect, please try again!
+    error_bar_invalid_credentials: Parece que su Apodo, Correo Electrónico, o Contraseña son incorrectos. Por favor intente nuevamente!
     error_birthdate: Se requiere fecha de nacimiento.
     error_birthdate_too_old: Usted es demasiado viejo.
     error_birthdate_too_young: Lo sentimos, debe usted tener 18 años o más para unirse.

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -374,7 +374,7 @@ pt:
   signup:
     almost_there: Quase Lá!
     error_bar: Dallas, temos um problema. Desloque para baixo para saber mais.
-    error_bar_invalid_credentials: Looks like your Nickname, Email or Password is incorrect, please try again!
+    error_bar_invalid_credentials: Parece que o Nome de Utilizador, Email, ou a Senha estão incorretos. Por favor tente novamente!
     error_birthdate: A data nascimento é obrigatória.
     error_birthdate_too_old: Você é muito velho.
     error_birthdate_too_young: Desculpe, você precisa de ter pelo menos 18 anos de idade para se poder registar.


### PR DESCRIPTION
From https://github.com/fetlife/translations/pull/259

I tried to maintain the translations as neutral between the various dialects (ie PT-PT vs PT-BR) as possible 😄 