### PR TITLE
Remove American Express from step 3 of Support flow

### DIFF
--- a/locales/bg.yml
+++ b/locales/bg.yml
@@ -566,7 +566,7 @@ bg:
         extra_info: We accept Visa, V Pay, Mastercard, and Maestro. It's easy and secure.
         title: Credit Card
       cc_trustpay:
-        extra_info: We accept Visa, Mastercard, and American Express. It's easy and secure.
+        extra_info: We accept Visa and Mastercard. It's easy and secure.
         title: Credit Card
       coingate:
         extra_info: Bitcoin is not as complicated as it sounds. And for the uninitiated, we will hold your hand through the process.

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -566,7 +566,7 @@ de:
         extra_info: Wir akzeptieren Visa, V Pay, Mastercard und Maestro. Es ist leicht und sicher.
         title: Kreditkarte
       cc_trustpay:
-        extra_info: Wir akzeptieren Visa, Mastercard und American Express. Es ist leicht und sicher.
+        extra_info: Wir akzeptieren Visa und Mastercard. Es ist leicht und sicher.
         title: Kreditkarte
       coingate:
         extra_info: Bitcoin ist gar nicht so kompliziert wie es sich anhört. Den Uneingeweihten helfen wir durch den Prozess.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -566,7 +566,7 @@ en:
         extra_info: We accept Visa, V Pay, Mastercard, and Maestro. It's easy and secure.
         title: Credit Card
       cc_trustpay:
-        extra_info: We accept Visa, Mastercard, and American Express. It's easy and secure.
+        extra_info: We accept Visa and Mastercard. It's easy and secure.
         title: Credit Card
       coingate:
         extra_info: Bitcoin is not as complicated as it sounds. And for the uninitiated, we will hold your hand through the process.

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -566,7 +566,7 @@ es:
         extra_info: Aceptamos Visa, V Pay, Mastercard y Maestro. Es sencillo y seguro.
         title: Tarjeta de crédito
       cc_trustpay:
-        extra_info: Aceptamos Visa, Mastercard y American Express. Es sencillo y seguro.
+        extra_info: Aceptamos Visa y Mastercard. Es sencillo y seguro.
         title: Tarjeta de crédito
       coingate:
         extra_info: Bitcoin is not as complicated as it sounds. And for the uninitiated, we will hold your hand through the process.

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -566,7 +566,7 @@ fr:
         extra_info: Nous acceptons Visa, V Pay, Mastercard et Maestro. C'est simple et sécurisé.
         title: Carte de crédit
       cc_trustpay:
-        extra_info: Nous acceptons Visa, Mastercard et American Express. C'est simple et sécurisé.
+        extra_info: Nous acceptons Visa et Mastercard. C'est simple et sécurisé.
         title: Carte de crédit
       coingate:
         extra_info: Les Bitcoin ne sont pas aussi compliqués qu’ils ne le paraissent. Et pour les non-initiés, nous vous guiderons pas à pas dans le processus.

--- a/locales/gr.yml
+++ b/locales/gr.yml
@@ -566,7 +566,7 @@ gr:
         extra_info: We accept Visa, V Pay, Mastercard, and Maestro. It's easy and secure.
         title: Credit Card
       cc_trustpay:
-        extra_info: We accept Visa, Mastercard, and American Express. It's easy and secure.
+        extra_info: We accept Visa and Mastercard. It's easy and secure.
         title: Credit Card
       coingate:
         extra_info: Bitcoin is not as complicated as it sounds. And for the uninitiated, we will hold your hand through the process.

--- a/locales/hu.yml
+++ b/locales/hu.yml
@@ -566,7 +566,7 @@ hu:
         extra_info: We accept Visa, V Pay, Mastercard, and Maestro. It's easy and secure.
         title: Credit Card
       cc_trustpay:
-        extra_info: We accept Visa, Mastercard, and American Express. It's easy and secure.
+        extra_info: We accept Visa and Mastercard. It's easy and secure.
         title: Credit Card
       coingate:
         extra_info: Bitcoin is not as complicated as it sounds. And for the uninitiated, we will hold your hand through the process.

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -566,7 +566,7 @@ it:
         extra_info: We accept Visa, V Pay, Mastercard, and Maestro. It's easy and secure.
         title: Credit Card
       cc_trustpay:
-        extra_info: We accept Visa, Mastercard, and American Express. It's easy and secure.
+        extra_info: We accept Visa and Mastercard. It's easy and secure.
         title: Credit Card
       coingate:
         extra_info: Bitcoin is not as complicated as it sounds. And for the uninitiated, we will hold your hand through the process.

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -566,7 +566,7 @@ nl:
         extra_info: We accept Visa, V Pay, Mastercard, and Maestro. It's easy and secure.
         title: Credit Card
       cc_trustpay:
-        extra_info: We accept Visa, Mastercard, and American Express. It's easy and secure.
+        extra_info: We accept Visa and Mastercard. It's easy and secure.
         title: Credit Card
       coingate:
         extra_info: Bitcoin is not as complicated as it sounds. And for the uninitiated, we will hold your hand through the process.

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -568,7 +568,7 @@ pl:
         extra_info: We accept Visa, V Pay, Mastercard, and Maestro. It's easy and secure.
         title: Credit Card
       cc_trustpay:
-        extra_info: We accept Visa, Mastercard, and American Express. It's easy and secure.
+        extra_info: We accept Visa and Mastercard. It's easy and secure.
         title: Credit Card
       coingate:
         extra_info: Bitcoin is not as complicated as it sounds. And for the uninitiated, we will hold your hand through the process.

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -566,7 +566,7 @@ pt:
         extra_info: Nós aceitamos Visa, V Pay, Mastercard, e Maestro. É simples e seguro.
         title: Cartão de crédito
       cc_trustpay:
-        extra_info: We accept Visa, Mastercard, and American Express. It's easy and secure.
+        extra_info: We accept Visa and Mastercard. It's easy and secure.
         title: Credit Card
       coingate:
         extra_info: A Bitcoin não é tão complicada como parece. E para os iniciados, nós acompanhamo-los durante o processo.

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -572,7 +572,7 @@ ru:
         extra_info: Мы принимаем Visa, V Pay, Mastercard и Maestro. Это легко и безопасно.
         title: Кредитная Карта
       cc_trustpay:
-        extra_info: Мы принимаем Visa, Mastercard и American Express. Это легко и безопасно.
+        extra_info: Мы принимаем Visa и Mastercard. Это легко и безопасно.
         title: Кредитная Карта
       coingate:
         extra_info: Биткоин не такой сложный, как кажется. И для непосвященных мы проведем вас за руку через этот процесс.

--- a/locales/sk.yml
+++ b/locales/sk.yml
@@ -571,7 +571,7 @@ sk:
         extra_info: We accept Visa, V Pay, Mastercard, and Maestro. It's easy and secure.
         title: Credit Card
       cc_trustpay:
-        extra_info: We accept Visa, Mastercard, and American Express. It's easy and secure.
+        extra_info: We accept Visa and Mastercard. It's easy and secure.
         title: Credit Card
       coingate:
         extra_info: Bitcoin is not as complicated as it sounds. And for the uninitiated, we will hold your hand through the process.

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -566,7 +566,7 @@ tr:
         extra_info: Visa, V Pay, Mastercard ve Maestro kabul ediyoruz. Kolay ve güvenli.
         title: Kredi Kartı
       cc_trustpay:
-        extra_info: Visa, Mastercard ve American Express kabul ediyoruz. Kolay ve güvenli.
+        extra_info: Visa ve Mastercard kabul ediyoruz. Kolay ve güvenli.
         title: Kredi Kartı
       coingate:
         extra_info: Bitcoin göründüğü kadar karmaşık değildir. Ve başlatılmamış olanlar için, süreç boyunca elinizi tutacağız.

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -566,7 +566,7 @@ zh:
         extra_info: We accept Visa, V Pay, Mastercard, and Maestro. It's easy and secure.
         title: Credit Card
       cc_trustpay:
-        extra_info: We accept Visa, Mastercard, and American Express. It's easy and secure.
+        extra_info: We accept Visa and Mastercard. It's easy and secure.
         title: Credit Card
       coingate:
         extra_info: Bitcoin is not as complicated as it sounds. And for the uninitiated, we will hold your hand through the process.


### PR DESCRIPTION
Removes mention of American Express since we don't support AMEX.