### PR TITLE
Add missing navigation translations

### DIFF
--- a/locales/bg.yml
+++ b/locales/bg.yml
@@ -228,6 +228,7 @@ bg:
     events: Събития
     explore: Разгледай
     fetishes: Фетиши
+    fetlife_status: Status FetLife
     groups: Групи
     home: Начало
     menu: Menu

--- a/locales/bg.yml
+++ b/locales/bg.yml
@@ -142,6 +142,11 @@ bg:
       group_leader: За водачи на група
       values: Values
     title: Правила
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: отмени
     cancel_notice: Поканата към %{email} беше отменена.
@@ -225,6 +230,10 @@ bg:
     fetishes: Фетиши
     groups: Групи
     home: Начало
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: Места
     search_placeholder: Търси във FetLife
     videos: Videos
@@ -326,6 +335,7 @@ bg:
     title: Смени имейл адреса
   sidebar:
     about_fetlife: Екипът ни
+    account_settings: Account Settings
     advertisers: All Advertisers
     advertising: Рекламиране
     already_member: Already a member?
@@ -353,6 +363,7 @@ bg:
     guiding_values: Guiding Values
     home: Начало
     invite_a_friend: Покани приятел (%{count})
+    invites: Invites
     kp: Извратено & Популярно
     legal_requests: Legal Request
     legalese: Правни въпроси
@@ -360,12 +371,17 @@ bg:
     login: Вход
     loved_stuff: Харесани
     need_help: Трябва ти помощ?
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: Отворен код
     places: Места
     privacy: Поверителност
+    privacy_options: Privacy Options
     privacy_policy: Privacy Policy
     pwa: Add FetLife to Home Screen
     recommendations: Препоръчани
+    show_account_menu: Show Account Menu
     signup: Регистрация
     support: Подкрепи FetLife
     terms: Условия
@@ -376,11 +392,14 @@ bg:
       need_help: Need Help?
     transparency: Transparency
     trust_and_safety: Trust & Safety
+    upcoming_events: Upcoming Events
     upload_picture: Качи снимка
     upload_video: Качи клип
     verification_pending: Profile Verification Pending
+    verify_profile: Verify Profile
     videos: Videos
     view_friends: Виж приятелите
+    view_profile: view profile
     view_terms: View Terms of Use
     wallpapers: FetLife Wallpapers
     whats_new: Какво ново
@@ -589,6 +608,9 @@ bg:
       coingate:
         extra_info: We accept Bitcoin, Ethereum, Dogecoin, Litecoin, XRP, and Dash.
         title: Cryptocurrency
+      curo_sepa:
+        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
+        title: European Bank Transfer (SEPA)
       eps:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports EPS in Austria.
         title: Austrian Bank Transfer (EPS)
@@ -619,9 +641,6 @@ bg:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account in Poland.
         title: Przelewy24
       sepa:
-        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
-        title: European Bank Transfer (SEPA)
-      curo_sepa:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
         title: European Bank Transfer (SEPA)
       teleingreso:
@@ -746,14 +765,14 @@ bg:
       secure: Secure as Fort Knox and we don't store any of your personal information.
       title: iDEAL Payment
     step3_interac:
-      amount: 'Amount'
-      answer_label: 'Answer'
+      amount: Amount
+      answer_label: Answer
       answer_placeholder: Answer
       cta: I've Sent the Interac e-Transfer
       message: Message
-      question_label: 'Security Question'
+      question_label: Security Question
       question_placeholder: Security Question
-      send: 'Send to'
+      send: Send to
       thank_you: Thank You!
       title: Send Interac e-Transfer
     step3_mail:

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -142,6 +142,11 @@ de:
       group_leader: Gruppenleitung
       values: Werte
     title: Richtlinien
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: Abbrechen
     cancel_notice: Die Einladung an %{email} wurde zurückgezogen.
@@ -225,6 +230,10 @@ de:
     fetishes: Fetische
     groups: Gruppen
     home: Zuhause
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: Orte
     search_placeholder: FetLife durchsuchen
     videos: Videos
@@ -326,6 +335,7 @@ de:
     title: E-Mail-Adresse aktualisieren
   sidebar:
     about_fetlife: Über FetLife
+    account_settings: Account Settings
     advertisers: Alle Werbetreibenden
     advertising: Werbung
     already_member: Bereits Mitglied?
@@ -353,6 +363,7 @@ de:
     guiding_values: Leitprinzipien
     home: Zuhause
     invite_a_friend: Lade Leute ein (%{count})
+    invites: Invites
     kp: Kinky & Beliebt
     legal_requests: Rechtliche Ersuchen
     legalese: Juristenjargon
@@ -360,12 +371,17 @@ de:
     login: Einloggen
     loved_stuff: Von dir geliebt
     need_help: Hilfe
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: Open Source
     places: Orte
     privacy: Privatsphäre
+    privacy_options: Privacy Options
     privacy_policy: Datenschutzrichtlinie
     pwa: FetLife zum Startbildschirm hinzufügen
     recommendations: Empfehlungen
+    show_account_menu: Show Account Menu
     signup: Registrieren
     support: Unterstütze FetLife
     terms: Nutzungsbedingungen
@@ -376,11 +392,14 @@ de:
       need_help: Brauchst du Hilfe?
     transparency: Transparenz
     trust_and_safety: Vertrauen & Sicherheit
+    upcoming_events: Upcoming Events
     upload_picture: Neues Bild
     upload_video: Neues Video
     verification_pending: Profilverifizierung ausstehend
+    verify_profile: Verify Profile
     videos: Videos
     view_friends: Freundesliste
+    view_profile: view profile
     view_terms: Nutzungsbedingungen ansehen
     wallpapers: FetLife-Wallpapers
     whats_new: Neuigkeiten
@@ -589,6 +608,9 @@ de:
       coingate:
         extra_info: Wir akzeptieren Bitcoin, Ethereum, Dogecoin, Litecoin, XRP und Dash.
         title: Kryptowährung
+      curo_sepa:
+        extra_info: So einfach und sicher wie die Bezahlung mit Kreditkarte. Für diejenigen mit einem SEPA-fähigen Konto in Europa.
+        title: Europäische Kontoabbuchung (SEPA)
       eps:
         extra_info: So einfach und sicher wie die Bezahlung mit Kreditkarte. Für diejenigen mit einem EPS-fähigen Konto in Österreich.
         title: Österreichische Bezahloption (EPS)
@@ -619,9 +641,6 @@ de:
         extra_info: So einfach und sicher wie die Bezahlung mit Kreditkarte. Für diejenigen mit einem Konto in Polen.
         title: Przelewy24
       sepa:
-        extra_info: So einfach und sicher wie die Bezahlung mit Kreditkarte. Für diejenigen mit einem SEPA-fähigen Konto in Europa.
-        title: Europäische Kontoabbuchung (SEPA)
-      curo_sepa:
         extra_info: So einfach und sicher wie die Bezahlung mit Kreditkarte. Für diejenigen mit einem SEPA-fähigen Konto in Europa.
         title: Europäische Kontoabbuchung (SEPA)
       teleingreso:
@@ -746,14 +765,14 @@ de:
       secure: So sicher wie Fort Knox und wir speichern keine deiner persönlichen Daten.
       title: iDEAL-Bezahlung
     step3_interac:
-      amount: 'Betrag'
-      answer_label: 'Antwort'
+      amount: Betrag
+      answer_label: Antwort
       answer_placeholder: Antwort
       cta: Ich habe den Interac e-Transfer verschickt
       message: Message
-      question_label: 'Sicherheitsfrage'
+      question_label: Sicherheitsfrage
       question_placeholder: Sicherheitsfrage
-      send: 'Senden an'
+      send: Senden an
       thank_you: Danke!
       title: Interac e-Transfer versenden
     step3_mail:

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -228,6 +228,7 @@ de:
     events: Veranstaltungen
     explore: Entdecken
     fetishes: Fetische
+    fetlife_status: Status FetLife
     groups: Gruppen
     home: Zuhause
     menu: Menu

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -227,6 +227,7 @@ en:
   nav:
     events: Events
     explore: Explore
+    fetlife_status: Status FetLife
     fetishes: Fetishes
     groups: Groups
     home: Home

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -142,6 +142,11 @@ en:
       group_leader: Group Leader
       values: Values
     title: Guidelines
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: cancel
     cancel_notice: The invitation to %{email} has been canceled.
@@ -225,6 +230,10 @@ en:
     fetishes: Fetishes
     groups: Groups
     home: Home
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: Places
     search_placeholder: Search FetLife
     videos: Videos
@@ -325,12 +334,8 @@ en:
     subtitle: Just in case you forget your password.
     title: Update Email Address
   sidebar:
-    title:
-      about_fetlife: About FetLife
-      community: Community
-      legalese: Legalese
-      need_help: Need Help?
     about_fetlife: Meet the Team
+    account_settings: Account Settings
     advertisers: All Advertisers
     advertising: Advertising
     already_member: Already a member?
@@ -358,29 +363,43 @@ en:
     guiding_values: Guiding Values
     home: Home
     invite_a_friend: Invite a Friend (%{count})
+    invites: Invites
     kp: Kinky & Popular
-    legalese: Legalese
     legal_requests: Legal Request
+    legalese: Legalese
     log_out: Log Out
     login: Log In
     loved_stuff: Stuff You Love
     need_help: Help
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: Open Source
     places: Places
     privacy: Privacy
+    privacy_options: Privacy Options
     privacy_policy: Privacy Policy
     pwa: Add FetLife to Home Screen
     recommendations: Recommendations
+    show_account_menu: Show Account Menu
     signup: Join FetLife
     support: Support FetLife
     terms: Terms of Use
+    title:
+      about_fetlife: About FetLife
+      community: Community
+      legalese: Legalese
+      need_help: Need Help?
     transparency: Transparency
     trust_and_safety: Trust & Safety
+    upcoming_events: Upcoming Events
     upload_picture: Upload Picture
     upload_video: Upload Video
     verification_pending: Profile Verification Pending
+    verify_profile: Verify Profile
     videos: Videos
     view_friends: View Friends
+    view_profile: view profile
     view_terms: View Terms of Use
     wallpapers: FetLife Wallpapers
     whats_new: What's New
@@ -589,6 +608,9 @@ en:
       coingate:
         extra_info: We accept Bitcoin, Ethereum, Dogecoin, Litecoin, XRP, and Dash.
         title: Cryptocurrency
+      curo_sepa:
+        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
+        title: European Bank Transfer (SEPA)
       eps:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports EPS in Austria.
         title: Austrian Bank Transfer (EPS)
@@ -619,9 +641,6 @@ en:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account in Poland.
         title: Przelewy24
       sepa:
-        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
-        title: European Bank Transfer (SEPA)
-      curo_sepa:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
         title: European Bank Transfer (SEPA)
       teleingreso:
@@ -746,14 +765,14 @@ en:
       secure: Secure as Fort Knox and we don't store any of your personal information.
       title: iDEAL Payment
     step3_interac:
-      amount: 'Amount'
-      answer_label: 'Answer'
+      amount: Amount
+      answer_label: Answer
       answer_placeholder: Answer
       cta: I've Sent the Interac e-Transfer
       message: Message
-      question_label: 'Security Question'
+      question_label: Security Question
       question_placeholder: Security Question
-      send: 'Send to'
+      send: Send to
       thank_you: Thank You!
       title: Send Interac e-Transfer
     step3_mail:

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -228,6 +228,7 @@ es:
     events: Eventos
     explore: Explorar
     fetishes: Fetiches
+    fetlife_status: Status FetLife
     groups: Grupos
     home: Principal
     menu: Menu

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -142,6 +142,11 @@ es:
       group_leader: Líder de grupo
       values: Valores
     title: Directrices
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: cancelar
     cancel_notice: La invitación a %{email} ha sido cancelada.
@@ -225,6 +230,10 @@ es:
     fetishes: Fetiches
     groups: Grupos
     home: Principal
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: Lugares
     search_placeholder: Buscar en FetLife
     videos: Vídeos
@@ -326,6 +335,7 @@ es:
     title: Actualiza la dirección de correo electrónico
   sidebar:
     about_fetlife: Conozca a nuestro equipo
+    account_settings: Account Settings
     advertisers: All Advertisers
     advertising: Anuncios
     already_member: Already a member?
@@ -353,6 +363,7 @@ es:
     guiding_values: Guiding Values
     home: Principal
     invite_a_friend: Invitar a un amigo (%{count})
+    invites: Invites
     kp: Kinky & Popular
     legal_requests: Legal Request
     legalese: Leguleyos
@@ -360,12 +371,17 @@ es:
     login: Login
     loved_stuff: Cosas que ama
     need_help: "¿Necesita ayuda?"
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: Código abierto
     places: Lugares
     privacy: Privacidad
+    privacy_options: Privacy Options
     privacy_policy: Privacy Policy
     pwa: Add FetLife to Home Screen
     recommendations: Recomendaciones
+    show_account_menu: Show Account Menu
     signup: Únase a FetLife
     support: Apoyar a FetLife
     terms: Términos
@@ -376,11 +392,14 @@ es:
       need_help: Need Help?
     transparency: Transparency
     trust_and_safety: Trust & Safety
+    upcoming_events: Upcoming Events
     upload_picture: Subir foto
     upload_video: Subir vídeo
     verification_pending: Profile Verification Pending
+    verify_profile: Verify Profile
     videos: Vídeos
     view_friends: Ver amigos
+    view_profile: view profile
     view_terms: View Terms of Use
     wallpapers: FetLife Wallpapers
     whats_new: Qué hay de nuevo
@@ -589,6 +608,9 @@ es:
       coingate:
         extra_info: We accept Bitcoin, Ethereum, Dogecoin, Litecoin, XRP, and Dash.
         title: Cryptocurrency
+      curo_sepa:
+        extra_info: Tan sencillo y seguro como pagar con tarjeta de crédito para aquellos que tengan una cuenta bancaria que soporte SEPA en Europa.
+        title: Transferencia bancaria europea(SEPA)
       eps:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports EPS in Austria.
         title: Austrian Bank Transfer (EPS)
@@ -619,9 +641,6 @@ es:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account in Poland.
         title: Przelewy24
       sepa:
-        extra_info: Tan sencillo y seguro como pagar con tarjeta de crédito para aquellos que tengan una cuenta bancaria que soporte SEPA en Europa.
-        title: Transferencia bancaria europea(SEPA)
-      curo_sepa:
         extra_info: Tan sencillo y seguro como pagar con tarjeta de crédito para aquellos que tengan una cuenta bancaria que soporte SEPA en Europa.
         title: Transferencia bancaria europea(SEPA)
       teleingreso:
@@ -746,14 +765,14 @@ es:
       secure: Secure as Fort Knox and we don't store any of your personal information.
       title: iDEAL Payment
     step3_interac:
-      amount: 'Amount'
-      answer_label: 'Answer'
+      amount: Amount
+      answer_label: Answer
       answer_placeholder: Answer
       cta: I've Sent the Interac e-Transfer
       message: Message
-      question_label: 'Security Question'
+      question_label: Security Question
       question_placeholder: Security Question
-      send: 'Send to'
+      send: Send to
       thank_you: Thank You!
       title: Send Interac e-Transfer
     step3_mail:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -228,6 +228,7 @@ fr:
     events: Évènements
     explore: Explorer
     fetishes: Fétiches
+    fetlife_status: Status FetLife
     groups: Groupes
     home: Accueil
     menu: Menu

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -142,6 +142,11 @@ fr:
       group_leader: Chef de groupe
       values: Valeurs
     title: Lignes directrices
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: annuler
     cancel_notice: L’invitation à %{email} a été annulée.
@@ -225,6 +230,10 @@ fr:
     fetishes: Fétiches
     groups: Groupes
     home: Accueil
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: Endroits
     search_placeholder: Chercher FetLife
     videos: Videos
@@ -326,6 +335,7 @@ fr:
     title: Mettre à jour l’adresse mail
   sidebar:
     about_fetlife: À propos de Fetlife
+    account_settings: Account Settings
     advertisers: All Advertisers
     advertising: Publicité
     already_member: Déjà membre?
@@ -353,6 +363,7 @@ fr:
     guiding_values: Guiding Values
     home: Accueil
     invite_a_friend: Inviter un ami (%{count})
+    invites: Invites
     kp: Kinky & Popular
     legal_requests: Legal Request
     legalese: Légal
@@ -360,12 +371,17 @@ fr:
     login: Connexion
     loved_stuff: Trucs que vous aimez
     need_help: Besoin d’aide ?
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: Open source
     places: Endroits
     privacy: Confidentialité
+    privacy_options: Privacy Options
     privacy_policy: Privacy Policy
     pwa: Add FetLife to Home Screen
     recommendations: Recommandations
+    show_account_menu: Show Account Menu
     signup: Inscription
     support: Supporter FetLife
     terms: Conditions
@@ -376,11 +392,14 @@ fr:
       need_help: Need Help?
     transparency: Transparency
     trust_and_safety: Trust & Safety
+    upcoming_events: Upcoming Events
     upload_picture: Envoyer photos
     upload_video: Envoyer vidéo
     verification_pending: Profile Verification Pending
+    verify_profile: Verify Profile
     videos: Videos
     view_friends: Voir ami⋅e⋅s
+    view_profile: view profile
     view_terms: View Terms of Use
     wallpapers: FetLife Wallpapers
     whats_new: Quoi de neuf
@@ -589,6 +608,9 @@ fr:
       coingate:
         extra_info: We accept Bitcoin, Ethereum, Dogecoin, Litecoin, XRP, and Dash.
         title: Cryptocurrency
+      curo_sepa:
+        extra_info: Aussi pratique et sécurisé que de payer par carte, pour ceux qui ont un compte bancaire supportant SEPA en Europe.
+        title: Virement bancaire européen (SEPA)
       eps:
         extra_info: Aussi pratique et sécurisé que de payer par carte, pour ceux qui ont un compte bancaire supportant EPS en Autriche.
         title: Virement bancaire autrichien (EPS)
@@ -619,9 +641,6 @@ fr:
         extra_info: Aussi pratique et sécurisé que de payer par carte, pour ceux qui ont un compte bancaire en Pologne.
         title: Przelewy24
       sepa:
-        extra_info: Aussi pratique et sécurisé que de payer par carte, pour ceux qui ont un compte bancaire supportant SEPA en Europe.
-        title: Virement bancaire européen (SEPA)
-      curo_sepa:
         extra_info: Aussi pratique et sécurisé que de payer par carte, pour ceux qui ont un compte bancaire supportant SEPA en Europe.
         title: Virement bancaire européen (SEPA)
       teleingreso:
@@ -746,14 +765,14 @@ fr:
       secure: Secure as Fort Knox and we don't store any of your personal information.
       title: iDEAL Payment
     step3_interac:
-      amount: 'Montant'
-      answer_label: 'Réponse'
+      amount: Montant
+      answer_label: Réponse
       answer_placeholder: Réponse
       cta: J’ai envoyé l’Interac e-Transfer
       message: Message
-      question_label: 'Question de sécurité'
+      question_label: Question de sécurité
       question_placeholder: Question de sécurité
-      send: 'Envoyé à'
+      send: Envoyé à
       thank_you: Merci !
       title: Envoyer un Interac e-Transfer
     step3_mail:

--- a/locales/gr.yml
+++ b/locales/gr.yml
@@ -228,6 +228,7 @@ gr:
     events: Εκδηλώσεις
     explore: Εξερεύνηση
     fetishes: Φετίχ
+    fetlife_status: Status FetLife
     groups: Ομάδες
     home: Αρχική σελίδα
     menu: Menu

--- a/locales/gr.yml
+++ b/locales/gr.yml
@@ -142,6 +142,11 @@ gr:
       group_leader: Αρχηγός Ομάδας
       values: Values
     title: Kατευθυντήριες Γραμμές
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: ακύρωση
     cancel_notice: H πρόσκληση στο %{email} ακυρώθηκε.
@@ -225,6 +230,10 @@ gr:
     fetishes: Φετίχ
     groups: Ομάδες
     home: Αρχική σελίδα
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: Μέρη
     search_placeholder: Αναζήτηση
     videos: Videos
@@ -326,6 +335,7 @@ gr:
     title: Επαναφέρετε τη διεύθυνση email
   sidebar:
     about_fetlife: Σχετικά με το Fetlife
+    account_settings: Account Settings
     advertisers: All Advertisers
     advertising: Διαφήμιση
     already_member: Already a member?
@@ -353,6 +363,7 @@ gr:
     guiding_values: Guiding Values
     home: Αρχική
     invite_a_friend: Προσκαλέστε ένα Φίλο (%{count})
+    invites: Invites
     kp: Διαστροφικά & Δημοφιλή
     legal_requests: Legal Request
     legalese: Νομικά
@@ -360,12 +371,17 @@ gr:
     login: Login
     loved_stuff: Πράγματα Που Αγαπάτε
     need_help: Χρειάζεστε βοήθεια?
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: Open Source
     places: Μέρη
     privacy: Privacy
+    privacy_options: Privacy Options
     privacy_policy: Privacy Policy
     pwa: Add FetLife to Home Screen
     recommendations: Προτάσεις
+    show_account_menu: Show Account Menu
     signup: Signup
     support: Υποστηρίξτε το Fetlife
     terms: Terms
@@ -376,11 +392,14 @@ gr:
       need_help: Need Help?
     transparency: Transparency
     trust_and_safety: Trust & Safety
+    upcoming_events: Upcoming Events
     upload_picture: Μεταφόρτωση Εικόνων
     upload_video: Μεταφόρτωση Βίντεο
     verification_pending: Profile Verification Pending
+    verify_profile: Verify Profile
     videos: Videos
     view_friends: Προβολή Φίλων
+    view_profile: view profile
     view_terms: View Terms of Use
     wallpapers: FetLife Wallpapers
     whats_new: Τι νέο υπάρχει
@@ -589,6 +608,9 @@ gr:
       coingate:
         extra_info: We accept Bitcoin, Ethereum, Dogecoin, Litecoin, XRP, and Dash.
         title: Cryptocurrency
+      curo_sepa:
+        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
+        title: European Bank Transfer (SEPA)
       eps:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports EPS in Austria.
         title: Austrian Bank Transfer (EPS)
@@ -619,9 +641,6 @@ gr:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account in Poland.
         title: Przelewy24
       sepa:
-        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
-        title: European Bank Transfer (SEPA)
-      curo_sepa:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
         title: European Bank Transfer (SEPA)
       teleingreso:
@@ -746,14 +765,14 @@ gr:
       secure: Secure as Fort Knox and we don't store any of your personal information.
       title: iDEAL Payment
     step3_interac:
-      amount: 'Amount'
-      answer_label: 'Answer'
+      amount: Amount
+      answer_label: Answer
       answer_placeholder: Answer
       cta: I've Sent the Interac e-Transfer
       message: Message
-      question_label: 'Security Question'
+      question_label: Security Question
       question_placeholder: Security Question
-      send: 'Send to'
+      send: Send to
       thank_you: Thank You!
       title: Send Interac e-Transfer
     step3_mail:

--- a/locales/hu.yml
+++ b/locales/hu.yml
@@ -142,6 +142,11 @@ hu:
       group_leader: Csoportgazda
       values: Values
     title: Irányelvekek
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: visszavonás
     cancel_notice: A(z) %{email} címre küldött meghívó visszavonva.
@@ -225,6 +230,10 @@ hu:
     fetishes: Fétisek
     groups: Csoportok
     home: Otthon
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: Helyek
     search_placeholder: Keresés
     videos: Videók
@@ -326,6 +335,7 @@ hu:
     title: Email cím frissítése
   sidebar:
     about_fetlife: Amit a Fetlife-ról tudni lehet
+    account_settings: Account Settings
     advertisers: All Advertisers
     advertising: Hirdetés
     already_member: Already a member?
@@ -353,6 +363,7 @@ hu:
     guiding_values: Guiding Values
     home: Otthon
     invite_a_friend: Ismerős meghívása (%{count})
+    invites: Invites
     kp: Kinky & Popular
     legal_requests: Legal Request
     legalese: Legalizáció
@@ -360,12 +371,17 @@ hu:
     login: Login
     loved_stuff: Amiket szerettél
     need_help: Segíthetünk?
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: Open Source
     places: Helyek
     privacy: Privacy
+    privacy_options: Privacy Options
     privacy_policy: Privacy Policy
     pwa: Add FetLife to Home Screen
     recommendations: Javaslatok
+    show_account_menu: Show Account Menu
     signup: Signup
     support: Támogasd a FetLife-ot
     terms: Feltételek
@@ -376,11 +392,14 @@ hu:
       need_help: Need Help?
     transparency: Transparency
     trust_and_safety: Trust & Safety
+    upcoming_events: Upcoming Events
     upload_picture: Kép feltöltése
     upload_video: Videó feltöltése
     verification_pending: Profile Verification Pending
+    verify_profile: Verify Profile
     videos: Videók
     view_friends: Ismerősök
+    view_profile: view profile
     view_terms: View Terms of Use
     wallpapers: FetLife Wallpapers
     whats_new: Újdonságok
@@ -589,6 +608,9 @@ hu:
       coingate:
         extra_info: We accept Bitcoin, Ethereum, Dogecoin, Litecoin, XRP, and Dash.
         title: Cryptocurrency
+      curo_sepa:
+        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
+        title: European Bank Transfer (SEPA)
       eps:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports EPS in Austria.
         title: Austrian Bank Transfer (EPS)
@@ -619,9 +641,6 @@ hu:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account in Poland.
         title: Przelewy24
       sepa:
-        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
-        title: European Bank Transfer (SEPA)
-      curo_sepa:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
         title: European Bank Transfer (SEPA)
       teleingreso:
@@ -746,14 +765,14 @@ hu:
       secure: Secure as Fort Knox and we don't store any of your personal information.
       title: iDEAL Payment
     step3_interac:
-      amount: 'Amount'
-      answer_label: 'Answer'
+      amount: Amount
+      answer_label: Answer
       answer_placeholder: Answer
       cta: I've Sent the Interac e-Transfer
       message: Message
-      question_label: 'Security Question'
+      question_label: Security Question
       question_placeholder: Security Question
-      send: 'Send to'
+      send: Send to
       thank_you: Thank You!
       title: Send Interac e-Transfer
     step3_mail:

--- a/locales/hu.yml
+++ b/locales/hu.yml
@@ -228,6 +228,7 @@ hu:
     events: Események
     explore: Felfedezés
     fetishes: Fétisek
+    fetlife_status: Status FetLife
     groups: Csoportok
     home: Otthon
     menu: Menu

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -228,6 +228,7 @@ it:
     events: Eventi
     explore: Esplora
     fetishes: Feticci
+    fetlife_status: Status FetLife
     groups: Gruppi
     home: Home
     menu: Menu

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -142,6 +142,11 @@ it:
       group_leader: Amministratore del gruppo
       values: Valori
     title: Linee guida
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: annulla
     cancel_notice: L'invito a %{email} è stato cancellato.
@@ -225,6 +230,10 @@ it:
     fetishes: Feticci
     groups: Gruppi
     home: Home
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: Luoghi
     search_placeholder: Cerca
     videos: Video
@@ -326,6 +335,7 @@ it:
     title: Aggiorna l'indirizzo email
   sidebar:
     about_fetlife: A proposito di Fetlife
+    account_settings: Account Settings
     advertisers: All Advertisers
     advertising: Pubblicità
     already_member: Sei già un membro?
@@ -353,6 +363,7 @@ it:
     guiding_values: Guiding Values
     home: Home
     invite_a_friend: Invita un* amic* (%{count})
+    invites: Invites
     kp: Kinky & Popular
     legal_requests: Legal Request
     legalese: Legalese
@@ -360,12 +371,17 @@ it:
     login: Login
     loved_stuff: Cose che ami
     need_help: Serve aiuto?
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: Open Source
     places: Luoghi
     privacy: Privacy
+    privacy_options: Privacy Options
     privacy_policy: Privacy Policy
     pwa: Add FetLife to Home Screen
     recommendations: Raccomandazioni
+    show_account_menu: Show Account Menu
     signup: Iscriviti
     support: Supporta FetLife
     terms: Terms
@@ -376,11 +392,14 @@ it:
       need_help: Need Help?
     transparency: Transparency
     trust_and_safety: Trust & Safety
+    upcoming_events: Upcoming Events
     upload_picture: Carica una foto
     upload_video: Carica un video
     verification_pending: Profile Verification Pending
+    verify_profile: Verify Profile
     videos: Video
     view_friends: Visualizza gli amici
+    view_profile: view profile
     view_terms: View Terms of Use
     wallpapers: Sfondi di Fetlife
     whats_new: Cosa c'è di nuovo
@@ -589,6 +608,9 @@ it:
       coingate:
         extra_info: We accept Bitcoin, Ethereum, Dogecoin, Litecoin, XRP, and Dash.
         title: Cryptocurrency
+      curo_sepa:
+        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
+        title: European Bank Transfer (SEPA)
       eps:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports EPS in Austria.
         title: Austrian Bank Transfer (EPS)
@@ -619,9 +641,6 @@ it:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account in Poland.
         title: Przelewy24
       sepa:
-        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
-        title: European Bank Transfer (SEPA)
-      curo_sepa:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
         title: European Bank Transfer (SEPA)
       teleingreso:
@@ -746,14 +765,14 @@ it:
       secure: Secure as Fort Knox and we don't store any of your personal information.
       title: iDEAL Payment
     step3_interac:
-      amount: 'Amount'
-      answer_label: 'Answer'
+      amount: Amount
+      answer_label: Answer
       answer_placeholder: Answer
       cta: I've Sent the Interac e-Transfer
       message: Message
-      question_label: 'Security Question'
+      question_label: Security Question
       question_placeholder: Security Question
-      send: 'Send to'
+      send: Send to
       thank_you: Thank You!
       title: Send Interac e-Transfer
     step3_mail:

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -228,6 +228,7 @@ nl:
     events: Bijeenkomsten
     explore: Verkennen
     fetishes: Fetishes
+    fetlife_status: Status FetLife
     groups: Groepen
     home: Thuis
     menu: Menu

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -142,6 +142,11 @@ nl:
       group_leader: Groep Leider
       values: Values
     title: Regels
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: afbreken
     cancel_notice: De uitnodiging van %{email} is afgebroken.
@@ -225,6 +230,10 @@ nl:
     fetishes: Fetishes
     groups: Groepen
     home: Thuis
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: Plaatsen
     search_placeholder: Zoeken op FetLife
     videos: Videos
@@ -326,6 +335,7 @@ nl:
     title: E-mailadres bijwerken
   sidebar:
     about_fetlife: Ontmoet het team
+    account_settings: Account Settings
     advertisers: All Advertisers
     advertising: Adverteren
     already_member: Al een lid?
@@ -353,6 +363,7 @@ nl:
     guiding_values: Guiding Values
     home: Thuis
     invite_a_friend: Nodig een vriend uit (%{count})
+    invites: Invites
     kp: Kinky & Populair
     legal_requests: Legal Request
     legalese: juridisch jargon
@@ -360,12 +371,17 @@ nl:
     login: Aanmelden
     loved_stuff: Snoepjes
     need_help: Hulp nodig?
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: Open bron
     places: Plaatsen
     privacy: Privacy
+    privacy_options: Privacy Options
     privacy_policy: Privacy Policy
     pwa: Add FetLife to Home Screen
     recommendations: Aanbevelingen
+    show_account_menu: Show Account Menu
     signup: Registreren
     support: Ondersteun FetLife
     terms: Terms
@@ -376,11 +392,14 @@ nl:
       need_help: Need Help?
     transparency: Transparency
     trust_and_safety: Trust & Safety
+    upcoming_events: Upcoming Events
     upload_picture: Foto plaatsen
     upload_video: Video plaatsen
     verification_pending: Profile Verification Pending
+    verify_profile: Verify Profile
     videos: Video's
     view_friends: Vrienden bekijken
+    view_profile: view profile
     view_terms: View Terms of Use
     wallpapers: FetLife Wallpapers
     whats_new: Wat is nieuw
@@ -589,6 +608,9 @@ nl:
       coingate:
         extra_info: We accept Bitcoin, Ethereum, Dogecoin, Litecoin, XRP, and Dash.
         title: Cryptocurrency
+      curo_sepa:
+        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
+        title: European Bank Transfer (SEPA)
       eps:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports EPS in Austria.
         title: Austrian Bank Transfer (EPS)
@@ -619,9 +641,6 @@ nl:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account in Poland.
         title: Przelewy24
       sepa:
-        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
-        title: European Bank Transfer (SEPA)
-      curo_sepa:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
         title: European Bank Transfer (SEPA)
       teleingreso:
@@ -746,14 +765,14 @@ nl:
       secure: Secure as Fort Knox and we don't store any of your personal information.
       title: iDEAL Payment
     step3_interac:
-      amount: 'Amount'
-      answer_label: 'Answer'
+      amount: Amount
+      answer_label: Answer
       answer_placeholder: Answer
       cta: I've Sent the Interac e-Transfer
       message: Message
-      question_label: 'Security Question'
+      question_label: Security Question
       question_placeholder: Security Question
-      send: 'Send to'
+      send: Send to
       thank_you: Thank You!
       title: Send Interac e-Transfer
     step3_mail:

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -32,9 +32,9 @@ pl:
     comment: Skomentuj
     comments_count:
       few: "%{count_with_delimiter} komentarze"
+      many: "%{count_with_delimiter} komentarzy"
       one: 1 komentarz
       other: "%{count_with_delimiter} komentarzy"
-      many: "%{count_with_delimiter} komentarzy"
     composer:
       button: Powiedz to!
       placeholder: I co Ty na to?
@@ -42,8 +42,8 @@ pl:
     loved_hover: Łamacz serc! :-(
     loves_count:
       few: "%{count_with_delimiter} serducha"
-      one: 1 Serducho
       many: "%{count_with_delimiter} serduch"
+      one: 1 Serducho
       other: "%{count_with_delimiter} serduch"
     modal:
       close: zamknij
@@ -146,6 +146,11 @@ pl:
       group_leader: Lider grupy
       values: Values
     title: Wytyczne
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: anuluj
     cancel_notice: Anulowano zaproszenie dla %{email}.
@@ -161,10 +166,10 @@ pl:
     next_step: następny krok
     return_to_feed: powrót do dziennika
     subtitle_step1:
-      one: Zostało Ci 1 zaproszenie.
-      other: 'Pozostało zaproszeń: %{count_with_delimiter}.'
       few: 'Pozostało zaproszeń: %{count_with_delimiter}.'
       many: 'Pozostało zaproszeń: %{count_with_delimiter}.'
+      one: Zostało Ci 1 zaproszenie.
+      other: 'Pozostało zaproszeń: %{count_with_delimiter}.'
     subtitle_step2: Wysłaliśmy zaproszenie od Ciebie dla %{email}.
     title_step1: Zaproś znajomego
     title_step2: Zaproszenie wysłane
@@ -217,19 +222,19 @@ pl:
     title: Będziemy tęsknić!
   member_stats:
     pics:
-      one: 1 fotka
       few: 'fotki: %{count_with_delimiter}'
       many: 'fotki: %{count_with_delimiter}'
+      one: 1 fotka
       other: 'fotki: %{count_with_delimiter}'
     posts:
-      one: 1 post
       few: 'posty: %{count_with_delimiter}'
       many: 'posty: %{count_with_delimiter}'
+      one: 1 post
       other: 'posty: %{count_with_delimiter}'
     vids:
-      one: 1 filmik
       few: 'filmiki: %{count_with_delimiter}'
       many: 'filmiki: %{count_with_delimiter}'
+      one: 1 filmik
       other: 'filmiki: %{count_with_delimiter}'
   nav:
     events: Wydarzenia
@@ -237,6 +242,10 @@ pl:
     fetishes: Fetysze
     groups: Grupy
     home: Główna
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: Miejsca
     search_placeholder: Wyszukaj na FetLife
     videos: Filmiki
@@ -338,6 +347,7 @@ pl:
     title: Zaktualizuj adres e-mail
   sidebar:
     about_fetlife: Poznaj nasz team
+    account_settings: Account Settings
     advertisers: All Advertisers
     advertising: Reklama
     already_member: Jesteś już członkiem?
@@ -365,6 +375,7 @@ pl:
     guiding_values: Guiding Values
     home: Start
     invite_a_friend: Zaproś znajomych (%{count})
+    invites: Invites
     kp: Kinky & Popular
     legal_requests: Legal Request
     legalese: Kwestie prawne
@@ -372,12 +383,17 @@ pl:
     login: Zaloguj się
     loved_stuff: To co kochasz
     need_help: Potrzebujesz pomocy?
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: Open Source
     places: Lokalizacje
     privacy: Prywatność
+    privacy_options: Privacy Options
     privacy_policy: Privacy Policy
     pwa: Add FetLife to Home Screen
     recommendations: Rekomendacje
+    show_account_menu: Show Account Menu
     signup: Dołącz do FetLife
     support: Wesprzyj FetLife
     terms: Zasady
@@ -388,11 +404,14 @@ pl:
       need_help: Need Help?
     transparency: Transparency
     trust_and_safety: Trust & Safety
+    upcoming_events: Upcoming Events
     upload_picture: Wgraj obrazek
     upload_video: Wgraj filmik
     verification_pending: Profile Verification Pending
+    verify_profile: Verify Profile
     videos: Filmiki
     view_friends: Pokaż znajomych
+    view_profile: view profile
     view_terms: View Terms of Use
     wallpapers: Tapety FetLife
     whats_new: Co nowego
@@ -601,6 +620,9 @@ pl:
       coingate:
         extra_info: We accept Bitcoin, Ethereum, Dogecoin, Litecoin, XRP, and Dash.
         title: Cryptocurrency
+      curo_sepa:
+        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
+        title: European Bank Transfer (SEPA)
       eps:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports EPS in Austria.
         title: Austrian Bank Transfer (EPS)
@@ -631,9 +653,6 @@ pl:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account in Poland.
         title: Przelewy24
       sepa:
-        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
-        title: European Bank Transfer (SEPA)
-      curo_sepa:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
         title: European Bank Transfer (SEPA)
       teleingreso:

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -240,6 +240,7 @@ pl:
     events: Wydarzenia
     explore: Eksploruj
     fetishes: Fetysze
+    fetlife_status: Status FetLife
     groups: Grupy
     home: Główna
     menu: Menu

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -142,6 +142,11 @@ pt:
       group_leader: Líder de Grupo
       values: Valores
     title: Orientações
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: Cancelar
     cancel_notice: O convite para %{email} foi cancelado.
@@ -225,6 +230,10 @@ pt:
     fetishes: Fetiches
     groups: Grupos
     home: Casa
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: Locais
     search_placeholder: Pesquisar
     videos: Vídeos
@@ -326,6 +335,7 @@ pt:
     title: Atualizar Endereço de Email
   sidebar:
     about_fetlife: Conheça a Equipa
+    account_settings: Account Settings
     advertisers: Todos os anunciantes
     advertising: Anúncios
     already_member: Já é um membro?
@@ -353,6 +363,7 @@ pt:
     guiding_values: Guiding Values
     home: Início
     invite_a_friend: Convide um Amigo (%{count})
+    invites: Invites
     kp: Kinky & Popular
     legal_requests: Legal Request
     legalese: Juridiquês
@@ -360,12 +371,17 @@ pt:
     login: Entrar
     loved_stuff: Coisas que você Ama
     need_help: Precisa de Ajuda?
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: Código Aberto
     places: Locais
     privacy: Privacidade
+    privacy_options: Privacy Options
     privacy_policy: Privacy Policy
     pwa: Add FetLife to Home Screen
     recommendations: Recomendações
+    show_account_menu: Show Account Menu
     signup: Junte-se ao Fetlife
     support: Apoie o FetLife
     terms: Termos
@@ -376,11 +392,14 @@ pt:
       need_help: Need Help?
     transparency: Transparency
     trust_and_safety: Trust & Safety
+    upcoming_events: Upcoming Events
     upload_picture: Enviar Foto
     upload_video: Enviar Vídeo
     verification_pending: Profile Verification Pending
+    verify_profile: Verify Profile
     videos: Vídeos
     view_friends: Ver Amigos
+    view_profile: view profile
     view_terms: View Terms of Use
     wallpapers: Imagens de fundo de ecrã do FetLife
     whats_new: O que há de novo
@@ -589,6 +608,9 @@ pt:
       coingate:
         extra_info: We accept Bitcoin, Ethereum, Dogecoin, Litecoin, XRP, and Dash.
         title: Cryptocurrency
+      curo_sepa:
+        extra_info: Tão fácil e seguro como pagar com cartão de crédito, para aqueles que possuem uma conta bancária que suporte SEPA na Europa.
+        title: Transferência bancária SEPA
       eps:
         extra_info: Tão fácil e seguro como pagar com cartão de crédito, para aqueles que possuem uma conta bancária na Áustria que suporte EPS.
         title: Transferência bancária Austríaca (EPS)
@@ -619,9 +641,6 @@ pt:
         extra_info: Tão fácil e seguro como pagar com cartão de crédito, para aqueles que possuem uma conta bancária na Polónia.
         title: Przelewy24
       sepa:
-        extra_info: Tão fácil e seguro como pagar com cartão de crédito, para aqueles que possuem uma conta bancária que suporte SEPA na Europa.
-        title: Transferência bancária SEPA
-      curo_sepa:
         extra_info: Tão fácil e seguro como pagar com cartão de crédito, para aqueles que possuem uma conta bancária que suporte SEPA na Europa.
         title: Transferência bancária SEPA
       teleingreso:
@@ -746,14 +765,14 @@ pt:
       secure: Seguro como o Fort Knox e nós não armazenamos qual informação pessoal sua.
       title: Pagamento iDEAL
     step3_interac:
-      amount: 'Montante'
-      answer_label: 'Resposta'
+      amount: Montante
+      answer_label: Resposta
       answer_placeholder: Resposta
       cta: Nós enviámos o Interac e-Transfer
       message: Message
-      question_label: 'Questão de segurança'
+      question_label: Questão de segurança
       question_placeholder: Questão de segurança
-      send: 'Enviar para'
+      send: Enviar para
       thank_you: Obrigado!
       title: Enviar Interac e-Transfer
     step3_mail:

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -228,6 +228,7 @@ pt:
     events: Eventos
     explore: Explorar
     fetishes: Fetiches
+    fetlife_status: Status FetLife
     groups: Grupos
     home: Casa
     menu: Menu

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -33,9 +33,9 @@ ru:
   feed:
     comment: Комментарий
     comments_count:
-      one: 1 Комментарий
       few: "%{count_with_delimiter} Комментариев"
       many: "%{count_with_delimiter} Комментариев"
+      one: 1 Комментарий
       other: "%{count_with_delimiter} Комментариев"
     composer:
       button: Отправить
@@ -43,9 +43,9 @@ ru:
     love: Любовь
     loved_hover: Сердце разбито! :-(
     loves_count:
-      one: 1 Любовь
       few: "%{count_with_delimiter} Любовь"
       many: "%{count_with_delimiter} Любовь"
+      one: 1 Любовь
       other: "%{count_with_delimiter} Любовь"
     modal:
       close: закрыть
@@ -152,6 +152,11 @@ ru:
       group_leader: Руководитель Группы
       values: Ценности
     title: Правила
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: отмена
     cancel_notice: Приглашение для %{email} было отозвано.
@@ -167,9 +172,9 @@ ru:
     next_step: следующий шаг
     return_to_feed: вернуться к ленте
     subtitle_step1:
-      one: У вас осталось 1 приглашение.
       few: У вас осталось %{count_with_delimiter} приглашений.
       many: У вас осталось %{count_with_delimiter} приглашений.
+      one: У вас осталось 1 приглашение.
       other: У вас осталось %{count_with_delimiter} приглашений.
     subtitle_step2: Мы отправили ваше приглашение %{email}.
     title_step1: Пригласить Друга
@@ -223,19 +228,19 @@ ru:
     title: Мы будем по вам скучать!
   member_stats:
     pics:
-      one: 1 фото
       few: "%{count_with_delimiter} фото"
       many: "%{count_with_delimiter} фото"
+      one: 1 фото
       other: "%{count_with_delimiter} фото"
     posts:
-      one: 1 пост
       few: "%{count_with_delimiter} постов"
       many: "%{count_with_delimiter} постов"
+      one: 1 пост
       other: "%{count_with_delimiter} постов"
     vids:
-      one: 1 видео
       few: "%{count_with_delimiter} видео"
       many: "%{count_with_delimiter} видео"
+      one: 1 видео
       other: "%{count_with_delimiter} видео"
   nav:
     events: Мероприятия
@@ -243,6 +248,10 @@ ru:
     fetishes: Фетиши
     groups: Группы
     home: Домой
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: Места
     search_placeholder: Искать на FetLife
     videos: Видео
@@ -344,6 +353,7 @@ ru:
     title: Обновить Адрес Эл.Почты
   sidebar:
     about_fetlife: Наша Команда
+    account_settings: Account Settings
     advertisers: All Advertisers
     advertising: Реклама
     already_member: Уже зарегистрированы?
@@ -371,6 +381,7 @@ ru:
     guiding_values: Guiding Values
     home: Home
     invite_a_friend: Пригласить Друга (%{count})
+    invites: Invites
     kp: Развратное & Популярное
     legal_requests: Legal Request
     legalese: Условия Использования
@@ -378,12 +389,17 @@ ru:
     login: Войти
     loved_stuff: Избранное
     need_help: Нужна Помощь?
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: Опенсорс
     places: Места
     privacy: Приватность
+    privacy_options: Privacy Options
     privacy_policy: Privacy Policy
     pwa: Add FetLife to Home Screen
     recommendations: Рекомендации
+    show_account_menu: Show Account Menu
     signup: Присоединиться к FetLife
     support: Поддержать FetLife
     terms: Условия
@@ -394,11 +410,14 @@ ru:
       need_help: Need Help?
     transparency: Transparency
     trust_and_safety: Trust & Safety
+    upcoming_events: Upcoming Events
     upload_picture: Загрузить Фото
     upload_video: Загрузить Видео
     verification_pending: Profile Verification Pending
+    verify_profile: Verify Profile
     videos: Видео
     view_friends: Посмотреть Друзей
+    view_profile: view profile
     view_terms: View Terms of Use
     wallpapers: FetLife Обои
     whats_new: Что Нового
@@ -607,6 +626,9 @@ ru:
       coingate:
         extra_info: We accept Bitcoin, Ethereum, Dogecoin, Litecoin, XRP, and Dash.
         title: Cryptocurrency
+      curo_sepa:
+        extra_info: Так же просто и безопасно, как оплата кредитной картой для тех, у кого есть банковский счет, который поддерживает SEPA в Европе.
+        title: European Bank Transfer (SEPA)
       eps:
         extra_info: Так же просто и безопасно, как оплата кредитной картой для тех, у кого есть банковский счет, который поддерживает EPS в Австрии.
         title: Austrian Bank Transfer (EPS)
@@ -637,9 +659,6 @@ ru:
         extra_info: Так же просто и безопасно, как оплата кредитной картой для тех, у кого есть банковский счет в Польше.
         title: Przelewy24
       sepa:
-        extra_info: Так же просто и безопасно, как оплата кредитной картой для тех, у кого есть банковский счет, который поддерживает SEPA в Европе.
-        title: European Bank Transfer (SEPA)
-      curo_sepa:
         extra_info: Так же просто и безопасно, как оплата кредитной картой для тех, у кого есть банковский счет, который поддерживает SEPA в Европе.
         title: European Bank Transfer (SEPA)
       teleingreso:

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -246,6 +246,7 @@ ru:
     events: Мероприятия
     explore: Исследовать
     fetishes: Фетиши
+    fetlife_status: Status FetLife
     groups: Группы
     home: Домой
     menu: Menu

--- a/locales/sk.yml
+++ b/locales/sk.yml
@@ -235,6 +235,7 @@ sk:
     events: Udalosti
     explore: Objavuj
     fetishes: Fetiše
+    fetlife_status: Status FetLife
     groups: Skupiny
     home: Domov
     menu: Menu

--- a/locales/sk.yml
+++ b/locales/sk.yml
@@ -40,9 +40,9 @@ sk:
     love: Ľúbi sa mi to
     loved_hover: Lámač sŕdc! :-(
     loves_count:
-      one: 1 členovi sa to ľúbi
       few: "%{count_with_delimiter} členom sa to ľúbi"
       many: "%{count_with_delimiter} členom sa to ľúbi"
+      one: 1 členovi sa to ľúbi
       other: "%{count_with_delimiter} členom sa to ľúbi"
     modal:
       close: zatvoriť
@@ -145,6 +145,11 @@ sk:
       group_leader: Líder skupiny
       values: Values
     title: Pravidlá
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: zrušiť
     cancel_notice: Pozvánka pre %{email} bola zrušená.
@@ -232,6 +237,10 @@ sk:
     fetishes: Fetiše
     groups: Skupiny
     home: Domov
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: Miesta
     search_placeholder: Hľadať
     videos: Videos
@@ -333,6 +342,7 @@ sk:
     title: Aktualizovať emailovú adresu
   sidebar:
     about_fetlife: O Fetlife
+    account_settings: Account Settings
     advertisers: All Advertisers
     advertising: Reklamné služby
     already_member: Already a member?
@@ -360,6 +370,7 @@ sk:
     guiding_values: Guiding Values
     home: Domov
     invite_a_friend: Pozvať priateľa (%{count})
+    invites: Invites
     kp: Kinky & Popular
     legal_requests: Legal Request
     legalese: Legislatíva
@@ -367,12 +378,17 @@ sk:
     login: Login
     loved_stuff: Stuff You Love
     need_help: Potrebuješ pomoc?
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: Open Source
     places: Miesta
     privacy: Privacy
+    privacy_options: Privacy Options
     privacy_policy: Privacy Policy
     pwa: Add FetLife to Home Screen
     recommendations: Odporúčania
+    show_account_menu: Show Account Menu
     signup: Signup
     support: Podpor FetLife
     terms: Terms
@@ -383,11 +399,14 @@ sk:
       need_help: Need Help?
     transparency: Transparency
     trust_and_safety: Trust & Safety
+    upcoming_events: Upcoming Events
     upload_picture: Nahraj fotku
     upload_video: Nahraj video
     verification_pending: Profile Verification Pending
+    verify_profile: Verify Profile
     videos: Videos
     view_friends: Zobraz priateľov
+    view_profile: view profile
     view_terms: View Terms of Use
     wallpapers: FetLife Wallpapers
     whats_new: Čo nové?
@@ -596,6 +615,9 @@ sk:
       coingate:
         extra_info: We accept Bitcoin, Ethereum, Dogecoin, Litecoin, XRP, and Dash.
         title: Cryptocurrency
+      curo_sepa:
+        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
+        title: European Bank Transfer (SEPA)
       eps:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports EPS in Austria.
         title: Austrian Bank Transfer (EPS)
@@ -626,9 +648,6 @@ sk:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account in Poland.
         title: Przelewy24
       sepa:
-        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
-        title: European Bank Transfer (SEPA)
-      curo_sepa:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
         title: European Bank Transfer (SEPA)
       teleingreso:

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -228,6 +228,7 @@ tr:
     events: Etkinlikler
     explore: Keşfet
     fetishes: Fetişler
+    fetlife_status: Status FetLife
     groups: Gruplar
     home: Anasayfa
     menu: Menu

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -142,6 +142,11 @@ tr:
       group_leader: Grup Lideri
       values: Values
     title: Rehberler
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: iptal
     cancel_notice: "%{email}'e gönderilen davet iptal edildi."
@@ -225,6 +230,10 @@ tr:
     fetishes: Fetişler
     groups: Gruplar
     home: Anasayfa
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: Yerler
     search_placeholder: FetLife'da Ara
     videos: Videolar
@@ -326,6 +335,7 @@ tr:
     title: Eposta Adresini Güncelle
   sidebar:
     about_fetlife: Ekiple Tanışın
+    account_settings: Account Settings
     advertisers: All Advertisers
     advertising: Reklam
     already_member: Zaten üye misiniz?
@@ -353,6 +363,7 @@ tr:
     guiding_values: Guiding Values
     home: Anasayfa
     invite_a_friend: Arkadaşını Davet Et (%{count})
+    invites: Invites
     kp: Kinky & Popular
     legal_requests: Legal Request
     legalese: Yasal
@@ -360,12 +371,17 @@ tr:
     login: Giriş Yap
     loved_stuff: Sevdiğiniz Şeyler
     need_help: Yardıma Mı İhtiyacınız Var?
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: Açık Kaynak
     places: Konumlar
     privacy: Gizlilik
+    privacy_options: Privacy Options
     privacy_policy: Privacy Policy
     pwa: Add FetLife to Home Screen
     recommendations: Öneriler
+    show_account_menu: Show Account Menu
     signup: FetLife'a Katılın
     support: FetLife'ı Destekleyin
     terms: Şartlar
@@ -376,11 +392,14 @@ tr:
       need_help: Need Help?
     transparency: Transparency
     trust_and_safety: Trust & Safety
+    upcoming_events: Upcoming Events
     upload_picture: Fotoğraf Yükle
     upload_video: Video Yükle
     verification_pending: Profile Verification Pending
+    verify_profile: Verify Profile
     videos: Videolar
     view_friends: Arkadaşları Gör
+    view_profile: view profile
     view_terms: View Terms of Use
     wallpapers: FetLife Duvar Kağıtları
     whats_new: Yeni Ne Var
@@ -589,6 +608,9 @@ tr:
       coingate:
         extra_info: We accept Bitcoin, Ethereum, Dogecoin, Litecoin, XRP, and Dash.
         title: Cryptocurrency
+      curo_sepa:
+        extra_info: Avrupa'da SEPA'yı destekleyen bir banka hesabına sahip olanlar için kredi kartıyla ödeme yapmak kadar kolay ve güvenli.
+        title: Avrupa Banka Havalesi (SEPA)
       eps:
         extra_info: Avusturya'da EPS'yi destekleyen bir banka hesabına sahip olanlar için kredi kartıyla ödeme yapmak kadar kolay ve güvenli.
         title: Avusturya Banka Havalesi (EPS)
@@ -619,9 +641,6 @@ tr:
         extra_info: Polonya'da bir banka hesabına sahip olanlar için kredi kartıyla ödeme yapmak kadar kolay ve güvenli.
         title: Przelewy24
       sepa:
-        extra_info: Avrupa'da SEPA'yı destekleyen bir banka hesabına sahip olanlar için kredi kartıyla ödeme yapmak kadar kolay ve güvenli.
-        title: Avrupa Banka Havalesi (SEPA)
-      curo_sepa:
         extra_info: Avrupa'da SEPA'yı destekleyen bir banka hesabına sahip olanlar için kredi kartıyla ödeme yapmak kadar kolay ve güvenli.
         title: Avrupa Banka Havalesi (SEPA)
       teleingreso:
@@ -746,14 +765,14 @@ tr:
       secure: Fort Knox gibi güvende ve kişisel hiçbir bilginizi saklamıyoruz.
       title: iDEAL Ödemesi
     step3_interac:
-      amount: 'Miktar'
-      answer_label: 'Cevap'
+      amount: Miktar
+      answer_label: Cevap
       answer_placeholder: Cevap
       cta: Interac e-Transfer'i gönderdim
       message: Message
-      question_label: 'Güvenlik Sorusu'
+      question_label: Güvenlik Sorusu
       question_placeholder: Güvenlik Sorusu
-      send: 'Gönderildi'
+      send: Gönderildi
       thank_you: Teşekkürler!
       title: Interac e-Transfer Gönder
     step3_mail:

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -228,6 +228,7 @@ zh:
     events: 线下活动
     explore: 发现
     fetishes: 癖好
+    fetlife_status: Status FetLife
     groups: 小组
     home: 首页
     menu: Menu

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -142,6 +142,11 @@ zh:
       group_leader: 小组管理员
       values: Values
     title: 守则
+  header:
+    friendship_requests_count: Friendship Requests (%{count})
+    inbox_count: Inbox (%{count})
+    notifications_count: Notifications (%{count})
+    post_new: Post Something New
   invite_a_friend:
     cancel_button: 取消
     cancel_notice: 发给 %{email} 的邀请已被撤销。
@@ -225,6 +230,10 @@ zh:
     fetishes: 癖好
     groups: 小组
     home: 首页
+    menu: Menu
+    menu_title: Show navigation menu
+    more: More
+    more_title: Navigate elsewhere
     places: 地方
     search_placeholder: 搜索 FetLife
     videos: 视频
@@ -326,6 +335,7 @@ zh:
     title: 更改邮件地址
   sidebar:
     about_fetlife: 关于 Fetlife
+    account_settings: Account Settings
     advertisers: All Advertisers
     advertising: 广告
     already_member: 已经注册过？
@@ -353,6 +363,7 @@ zh:
     guiding_values: Guiding Values
     home: 首页
     invite_a_friend: 邀请好友（%{count}）
+    invites: Invites
     kp: 众心所癖
     legal_requests: Legal Request
     legalese: 法律事宜
@@ -360,12 +371,17 @@ zh:
     login: 登录
     loved_stuff: 你赞过的东西
     need_help: 需要帮助？
+    new_status: Post Status Update
+    new_writing: New Writing
+    noification_preferences: Notification Preferences
     open_source: 开源
     places: 地方
     privacy: 隐私
+    privacy_options: Privacy Options
     privacy_policy: Privacy Policy
     pwa: Add FetLife to Home Screen
     recommendations: 推荐
+    show_account_menu: Show Account Menu
     signup: 注册
     support: 赞助 FetLife
     terms: 条款
@@ -376,11 +392,14 @@ zh:
       need_help: Need Help?
     transparency: Transparency
     trust_and_safety: Trust & Safety
+    upcoming_events: Upcoming Events
     upload_picture: 上传图片
     upload_video: 上传视频
     verification_pending: Profile Verification Pending
+    verify_profile: Verify Profile
     videos: 视频
     view_friends: 查看好友列表
+    view_profile: view profile
     view_terms: View Terms of Use
     wallpapers: FetLife 壁纸
     whats_new: 有啥新鲜的
@@ -589,6 +608,9 @@ zh:
       coingate:
         extra_info: We accept Bitcoin, Ethereum, Dogecoin, Litecoin, XRP, and Dash.
         title: Cryptocurrency
+      curo_sepa:
+        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
+        title: European Bank Transfer (SEPA)
       eps:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports EPS in Austria.
         title: Austrian Bank Transfer (EPS)
@@ -619,9 +641,6 @@ zh:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account in Poland.
         title: Przelewy24
       sepa:
-        extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
-        title: European Bank Transfer (SEPA)
-      curo_sepa:
         extra_info: As straightforward and secure as paying by credit card for those with a bank account that supports SEPA in Europe.
         title: European Bank Transfer (SEPA)
       teleingreso:
@@ -746,14 +765,14 @@ zh:
       secure: Secure as Fort Knox and we don't store any of your personal information.
       title: iDEAL Payment
     step3_interac:
-      amount: 'Amount'
-      answer_label: 'Answer'
+      amount: Amount
+      answer_label: Answer
       answer_placeholder: Answer
       cta: I've Sent the Interac e-Transfer
       message: Message
-      question_label: 'Security Question'
+      question_label: Security Question
       question_placeholder: Security Question
-      send: 'Send to'
+      send: Send to
       thank_you: Thank You!
       title: Send Interac e-Transfer
     step3_mail:


### PR DESCRIPTION
This PR adds translation keys missing for current navigation, as well as the new one that we're working on.

Some unrelated locales were changed because of the `bundle exec i18n-tasks normalize` task